### PR TITLE
Fix links in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,8 +28,8 @@
 .. _parse:
 
 Importing ``parsnip`` allows users to read `CIF 1.1 <https://www.iucr.org/resources/cif/spec/version1.1>`_ files, as well as many features from the `CIF 2.0 <https://www.iucr.org/resources/cif/cif2>`_ and `mmCIF <https://pdb101.rcsb.org/learn/guide-to-understanding-pdb-data/beginner’s-guide-to-pdb-structures-and-the-pdbx-mmcif-format>`_ formats.
-Creating a :class:`~.CifFile` object provides easy access to name-value :attr:`~.CifFile.pairs`, as well
-as `loop\_`-delimited :attr:`~.CifFile.tables`. Data entries can be extracted as python primitives or
+Creating a :class:`~.parsnip.CifFile` object provides easy access to name-value :attr:`~.parsnip.CifFile.pairs`, as well
+as data table :attr:`~.parsnip.CifFile.loops`. Data entries can be extracted as python primitives or
 numpy arrays for further use.
 
 .. _installing:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

Sphinx directives are not supported in GitHub readme files. Once the docs are public, the sphinx-generated links can be replaced with links to the readthedocs. This could be done now, but would result in some duplication of effort without significant benefit

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
Resolves #32

## Types of Changes
<!-- Please select all items that apply, either now or after creating the pull request: -->
- [ ] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality and should be merged into the `breaking` branch

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
- [ ] I am familiar with the [Development Guidelines](https://github.com/glotzerlab/parsnip/blob/main/doc/source/development.rst)
- [ ] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/parsnip/blob/main/ChangeLog.rst) and added my name to the [credits](https://github.com/glotzerlab/parsnip/blob/main/doc/source/credits.rst).
