### PR TITLE
Allow `build_unit_cell` to return atom site labels

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -4,6 +4,19 @@ Changelog
 The format is based on `Keep a Changelog <http://keepachangelog.com/en/1.1.0/>`__.
 This project adheres to `Semantic Versioning <http://semver.org/spec/v2.0.0.html>`__.
 
+v0.2.1 - 20XX-XX-XX
+-------------------
+
+Added
+~~~~~
+- New ``additional_columns`` parameter for ``build_unit_cell`` that allows the return of
+  atom site labels and similar data alongside unit cell positions.
+- Ensured consistent ordering of lattice positions returned from ``build_unit_cell``.
+
+Fixed
+~~~~~
+- Type hints now properly link to their associated documentation.
+
 v0.2.0 - 2025-02-19
 -------------------
 

--- a/parsnip/parsnip.py
+++ b/parsnip/parsnip.py
@@ -391,7 +391,7 @@ class CifFile:
             return result[0] if len(result) == 1 else result
 
         if isinstance(index, (set, frozenset)):
-            index = list(index)  # TODO: add to changelog
+            index = list(index)
 
         result, index = [], np.atleast_1d(index)
         for table in self.loops:

--- a/parsnip/parsnip.py
+++ b/parsnip/parsnip.py
@@ -460,10 +460,7 @@ class CifFile:
     def build_unit_cell(
         self,
         n_decimal_places: int = 4,
-        additional_columns: ArrayLike | None = [
-            "_atom_site_label",
-            "_atom_site_U_iso_or_equiv",
-        ],
+        additional_columns: ArrayLike | None = None,
         verbose: bool = False,
     ):
         """Reconstruct fractional atomic positions from Wyckoff sites and symops.

--- a/parsnip/parsnip.py
+++ b/parsnip/parsnip.py
@@ -410,11 +410,11 @@ class CifFile:
         Parameters
         ----------
             degrees : bool, optional
-                When True, angles are returned in degrees (as per the CIF spec). When
-                False, angles are converted to radians. Default value = ``True``
-            normalize: (bool, optional)
+                When ``True``, angles are returned in degrees (as in the CIF spec). When
+                ``False``, angles are converted to radians. Default value = ``True``
+            normalize: bool, optional
                 Whether to scale the unit cell such that the smallest lattice parameter
-                is `1.0`.
+                is ``1.0``.
                 Default value = ``False``
 
         Returns

--- a/parsnip/parsnip.py
+++ b/parsnip/parsnip.py
@@ -190,7 +190,7 @@ class CifFile:
         """Return an item or list of items from :meth:`~.pairs` and :meth:`~.loops`.
 
         This getter searches the entire CIF state to identify the input keys, returning
-        `None` if the key does not match any data. Matching columns from `loop` tables
+        ``None`` if the key does not match any data. Matching columns from `loop` tables
         are returned as 1D arrays.
 
         .. tip::
@@ -246,7 +246,7 @@ class CifFile:
             wildcard matches more than one key, a list is returned for that index.
 
         Indexing with a string returns the value from the :meth:`~.pairs` dict. Indexing
-        with an Iterable of strings returns a list of values, with `None` as a
+        with an Iterable of strings returns a list of values, with ``None`` as a
         placeholder for keys that did not match any data.
 
         Example

--- a/parsnip/parsnip.py
+++ b/parsnip/parsnip.py
@@ -554,19 +554,7 @@ class CifFile:
             self.get_from_loops(additional_columns), len(symops), axis=0
         )
 
-        # return tiled_data[unique_indices], pos[unique_indices]
-        return np.rec.array(
-            list(zip(*tiled_data.T, *pos.T)),
-            dtype=[
-                *[
-                    (label, tiled_data.dtype)
-                    for label in np.atleast_1d(additional_columns)
-                ],
-                ("x", float),
-                ("y", float),
-                ("z", float),
-            ],
-        )
+        return tiled_data[unique_indices], pos[unique_indices]
 
     @property
     def box(self):

--- a/parsnip/parsnip.py
+++ b/parsnip/parsnip.py
@@ -556,10 +556,7 @@ class CifFile:
         cell_matrix = _matrix_from_lengths_and_angles(*cell)
 
         symops_str = np.array2string(
-            symops,
-            separator=",",  # Place a comma after each line in the array for eval
-            threshold=np.inf,  # Ensure that every line is included in the string
-            floatmode="unique",  # Ensures strings can uniquely represent each float
+            symops, separator=",", threshold=np.inf, floatmode="unique"
         )
 
         all_frac_positions = [
@@ -591,6 +588,7 @@ class CifFile:
 
         # Merge unique points from realspace and fractional calculations
         unique_indices = sorted({*unique_fractional} & {*unique_realspace})
+        # TODO: Reintroduce AFLOW test suite
 
         if verbose:
             _write_debug_output(

--- a/parsnip/parsnip.py
+++ b/parsnip/parsnip.py
@@ -407,7 +407,7 @@ class CifFile:
         return _flatten_or_none(result)
 
     def read_cell_params(self, degrees: bool = True, normalize: bool = False):
-        r"""Read the `unit cell parameters`_ (lengths and angles) from a CIF file.
+        r"""Read the `unit cell parameters`_ (lengths and angles).
 
         .. _`unit cell parameters`: https://www.iucr.org/__data/iucr/cifdic_html/1/cif_core.dic/Ccell.html
 
@@ -695,7 +695,7 @@ class CifFile:
 
     @property
     def symops(self):
-        r"""Extract the symmetry operations from a CIF file.
+        r"""Extract the symmetry operations in a `parsable algebraic form`_.
 
         Example
         -------
@@ -708,8 +708,7 @@ class CifFile:
         Returns
         -------
             :math:`(N,1)` numpy.ndarray[str]:
-                An array of strings containing the symmetry operations in a
-                `parsable algebraic form`_.
+                An array containing the symmetry operations.
 
         .. _`parsable algebraic form`: https://www.iucr.org/__data/iucr/cifdic_html/1/cif_core.dic/Ispace_group_symop_operation_xyz.html
         """
@@ -718,7 +717,7 @@ class CifFile:
 
     @property
     def wyckoff_positions(self):
-        r"""Extract symmetry-irreducible, fractional x,y,z coordinates from a CIF file.
+        r"""Extract symmetry-irreducible, fractional `x,y,z` coordinates.
 
         Returns
         -------

--- a/parsnip/parsnip.py
+++ b/parsnip/parsnip.py
@@ -818,10 +818,10 @@ class CifFile:
 
                 if n_elements % n_cols != 0:
                     warnings.warn(
-                        f"Parsed data for table {len(self.loops) + 1} cannot be resolved"
-                        f" into a table of the expected size and will be ignored. "
-                        f"Got n={n_elements} items, expected c={n_cols} columns: "
-                        f"n%c={n_elements % n_cols}).",
+                        f"Parsed data for table {len(self.loops) + 1} cannot be"
+                        f" resolved into a table of the expected size and will be"
+                        f"ignored. Got n={n_elements} items, expected c={n_cols}"
+                        f"columns: n%c={n_elements % n_cols}).",
                         category=ParseWarning,
                         stacklevel=2,
                     )

--- a/parsnip/parsnip.py
+++ b/parsnip/parsnip.py
@@ -77,7 +77,6 @@ from typing import ClassVar
 import numpy as np
 from more_itertools import flatten, peekable
 from numpy.lib.recfunctions import structured_to_unstructured
-from numpy.typing import ArrayLike
 
 from parsnip._errors import ParseWarning
 from parsnip.patterns import (
@@ -182,7 +181,7 @@ class CifFile:
 
         Returns
         -------
-        list[:class:`numpy.ndarray[str]`]:
+        list[numpy.ndarray[str]]
             A list of structured arrays containing table data from the file.
         """
         return self._loops
@@ -223,6 +222,11 @@ class CifFile:
         >>> cif[["_journal*", "_atom_site_fract_?"]]
         [['1999', '0', '123'],
         ...array([['0.0000000000', '0.0000000000', '0.0000000000']], dtype='<U12')]
+
+        Parameters
+        ----------
+            index: str | typing.Iterable[str]
+                An item key or list of keys.
         """
         output = []
         index = [index] if isinstance(index, str) else index
@@ -237,9 +241,9 @@ class CifFile:
 
         .. tip::
 
-            This method supports a few unix-style wildcards. Use `*` to match any number
-            of any character, and `?` to match any single character. If a wildcard
-            matches more than one key, a list is returned for that index.
+            This method supports a few unix-style wildcards. Use ``*`` to match any
+            number of any character, and ``?`` to match any single character. If a
+            wildcard matches more than one key, a list is returned for that index.
 
         Indexing with a string returns the value from the :meth:`~.pairs` dict. Indexing
         with an Iterable of strings returns a list of values, with `None` as a
@@ -269,7 +273,7 @@ class CifFile:
 
         Parameters
         ----------
-            index: str | Iterable[str]
+            index: str | typing.Iterable[str]
                 An item key or list of keys.
 
         Returns
@@ -291,7 +295,7 @@ class CifFile:
 
         return [_flatten_or_none([self.pairs.get(k, None) for k in m]) for m in matches]
 
-    def get_from_loops(self, index: ArrayLike):
+    def get_from_loops(self, index: str | Iterable[str]):
         """Return a column or columns from the matching table in :attr:`~.loops`.
 
         If index is a single string, a single column will be returned from the matching
@@ -362,7 +366,7 @@ class CifFile:
 
         Parameters
         ----------
-            index: str | Iterable[str]
+            index: str | typing.Iterable[str]
                 A column name or list of column names.
 
         Returns
@@ -484,7 +488,8 @@ class CifFile:
                [0.5, 0. , 0.5],
                [0.5, 0.5, 0. ]])
 
-        Reconstruct a unit cell with its associated atomic labels:
+        Reconstruct a unit cell with its associated atomic labels. The ordering of the
+        auxiliary data array will match the ordering of the atomic positions:
 
         >>> atoms, pos = cif.build_unit_cell(additional_columns=["_atom_site_label"])
         >>> atoms
@@ -504,7 +509,7 @@ class CifFile:
                 The number of decimal places to round each position to for the
                 uniqueness comparison. Values higher than 4 may not work for all CIF
                 files. Default value = ``4``
-            additional_columns : str | Iterable[str] | None, optional
+            additional_columns : str | typing.Iterable[str] | None, optional
                 A column name or list of column names from the loop containing
                 the Wyckoff site positions. This data is replicated alongside the atomic
                 coordinates and returned in an auxiliary array.
@@ -527,7 +532,7 @@ class CifFile:
             positions.
 
 
-        .. warning::
+        .. caution::
 
             Reconstructing positions requires several floating point calculations that
             can be impacted by low-precision data in CIF files. Typically, at least four
@@ -702,7 +707,7 @@ class CifFile:
 
         Returns
         -------
-            :math:`(N,)` :class:`numpy.ndarray[str]`:
+            :math:`(N,1)` numpy.ndarray[str]:
                 An array of strings containing the symmetry operations in a
                 `parsable algebraic form`_.
 
@@ -710,7 +715,6 @@ class CifFile:
         """
         # Only one key is valid in each standard, so we only ever get one match.
         return self.get_from_loops(self.__class__._SYMOP_KEYS)
-        # TODO: shape is (N, 1), not (N, )
 
     @property
     def wyckoff_positions(self):
@@ -718,7 +722,7 @@ class CifFile:
 
         Returns
         -------
-            :math:`(N, 3)` :class:`numpy.ndarray[float]`:
+            :math:`(N, 3)` :class:`numpy.ndarray`:
                 Symmetry-irreducible positions of atoms in `fractional coordinates`_.
 
         .. _`fractional coordinates`: https://www.iucr.org/__data/iucr/cifdic_html/1/cif_core.dic/Iatom_site_fract_.html

--- a/parsnip/parsnip.py
+++ b/parsnip/parsnip.py
@@ -228,7 +228,6 @@ class CifFile:
         for key in index:
             pairs_match = self.get_from_pairs(key)
             loops_match = self.get_from_loops(key)
-            # print(pairs_match if pairs_match is not None else loops_match)
             output.append(pairs_match if pairs_match is not None else loops_match)
         return output[0] if len(output) == 1 else output
 
@@ -462,7 +461,6 @@ class CifFile:
         self,
         n_decimal_places: int = 4,
         additional_cols: ArrayLike | None = None,
-        # additional_cols: ArrayLike | None = "_atom_site_label",
         verbose: bool = False,
     ):
         """Reconstruct fractional atomic positions from Wyckoff sites and symops.
@@ -500,8 +498,9 @@ class CifFile:
         ------
         ValueError
             If the stored data cannot form a valid box.
-            If the `additional_cols` is not properly associated with the unit cell.
-        """  # TODO: does this format correctly?
+        ValueError
+            If the `additional_cols` are not properly associated with the unit cell.
+        """
         symops, fractional_positions = self.symops, self.wyckoff_positions
 
         if additional_cols is not None:
@@ -511,7 +510,6 @@ class CifFile:
                 for labels in self.loop_labels
                 if set(labels) & set(self.__class__._WYCKOFF_KEYS)
             )
-            print(invalid_keys)
             if invalid_keys:
                 msg = (
                     f"Requested keys {invalid_keys} are not included in the `_atom_site"
@@ -529,8 +527,6 @@ class CifFile:
             threshold=np.inf,  # Ensure that every line is included in the string
             floatmode="unique",  # Ensures strings can uniquely represent each float
         )
-        # print((symops_str,), "\n\n")
-        # print(symops_str, "\n")
 
         all_frac_positions = [
             _safe_eval(symops_str, *xyz) for xyz in fractional_positions
@@ -539,20 +535,9 @@ class CifFile:
         pos = np.vstack(all_frac_positions)
         pos %= 1  # Wrap particles into the box
 
-        # auxiliary_data =
-        # print([self.symops])
-        print(fractional_positions)
-        # print(pos[:8])
-        # print(pos.shape, fractional_positions.shape)
-        print(self.get_from_loops("_atom_site_label"))
-
         # Filter unique points. This takes some time but makes the method faster overall
         _, unique_indices, unique_counts = np.unique(
-            # pos.round(n_decimal_places), return_index=True, return_counts=True, axis=0
-            pos.round(n_decimal_places),
-            return_index=True,
-            return_counts=True,
-            axis=0,
+            pos.round(n_decimal_places), return_index=True, return_counts=True, axis=0
         )
         unique_indices.sort()  # TODO: is this correct?
 

--- a/parsnip/parsnip.py
+++ b/parsnip/parsnip.py
@@ -868,7 +868,6 @@ class CifFile:
         "_symmetry_equiv_pos_as_xyz",
         "_space_group_symop_operation_xyz",
     )
-    # TODO: cannot be set/frozenset: order matters!
     _WYCKOFF_KEYS = (
         "_atom_site_fract_x",
         "_atom_site_fract_y",

--- a/tests/test_unitcells.py
+++ b/tests/test_unitcells.py
@@ -61,8 +61,7 @@ def test_read_symmetry_operations(cif_data):
 
 
 @cif_files_mark
-# @pytest.mark.parametrize("n_decimal_places", [3, 4, 5, 6, 9])
-@pytest.mark.parametrize("n_decimal_places", [3])
+@pytest.mark.parametrize("n_decimal_places", [3, 4, 6, 9])
 @pytest.mark.parametrize(
     "cols",
     [

--- a/tests/test_unitcells.py
+++ b/tests/test_unitcells.py
@@ -1,4 +1,6 @@
+import re
 import warnings
+from contextlib import nullcontext
 
 import numpy as np
 import pytest
@@ -6,6 +8,7 @@ from ase import io
 from ase.build import supercells
 from conftest import box_keys, cif_files_mark
 from gemmi import cif
+from more_itertools import flatten
 
 
 def _gemmi_read_table(filename, keys):
@@ -17,6 +20,10 @@ def _gemmi_read_keys(filename, keys, as_number=True):
     if as_number:
         return np.array([cif.as_number(file_block.find_value(key)) for key in keys])
     return np.array([file_block.find_value(key) for key in keys])
+
+
+def _arrstrip(arr: np.ndarray, pattern: str):
+    return np.vectorize(lambda x: re.sub(pattern, "", x))(arr)
 
 
 @cif_files_mark  # TODO: test with conversions to numeric as well
@@ -54,17 +61,47 @@ def test_read_symmetry_operations(cif_data):
 
 
 @cif_files_mark
-@pytest.mark.parametrize("n_decimal_places", [3, 4, 5, 6, 9])
-def test_build_unit_cell(cif_data, n_decimal_places):
+# @pytest.mark.parametrize("n_decimal_places", [3, 4, 5, 6, 9])
+@pytest.mark.parametrize("n_decimal_places", [3])
+@pytest.mark.parametrize(
+    "cols",
+    [
+        None,
+        "_atom_site_type_symbol",
+        ["_atom_site_type_symbol", "_atom_site_occupancy"],
+    ],
+)
+def test_build_unit_cell(cif_data, n_decimal_places, cols):
     warnings.filterwarnings("ignore", "crystal system", category=UserWarning)
 
     if "PDB_4INS_head.cif" in cif_data.filename:
         return
 
-    parsnip_positions = (
-        cif_data.file.build_unit_cell(n_decimal_places=n_decimal_places)
-        @ cif_data.file.lattice_vectors.T
+    should_raise = cols is not None and any(
+        k not in flatten(cif_data.file.loop_labels) for k in np.atleast_1d(cols)
     )
+    occupancies, read_data = None, None
+    with (
+        pytest.raises(ValueError, match=r"not included in the `_atom_site_fract_\[xyz")
+        if should_raise
+        else nullcontext()
+    ):
+        read_data = cif_data.file.build_unit_cell(
+            n_decimal_places=n_decimal_places, additional_columns=cols
+        )
+
+    if read_data is None:
+        return  # ValueError was raised
+
+    if cols is None:
+        parsnip_positions = read_data @ cif_data.file.lattice_vectors.T
+    else:
+        auxiliary_arr, parsnip_positions = read_data
+        parsnip_positions @= cif_data.file.lattice_vectors.T
+
+        che_symbols = _arrstrip(auxiliary_arr[:, 0], r"[^A-Za-z]+")
+        if isinstance(cols, list):
+            occupancies = _arrstrip(auxiliary_arr[:, 1], r"[^\d\.]+").astype(float)
 
     # Read the structure, then extract to Python builtin types. Then, wrap into the box
     ase_file = io.read(cif_data.filename)
@@ -77,10 +114,20 @@ def test_build_unit_cell(cif_data, n_decimal_places):
     ase_positions = np.array(
         sorted(ase_data.get_positions(), key=lambda x: (x[0], x[1], x[2]))
     )
+    ase_symbols = np.array(ase_data.get_chemical_symbols())
 
     parsnip_minmax = [parsnip_positions.min(axis=0), parsnip_positions.max(axis=0)]
     ase_minmax = [ase_positions.min(axis=0), ase_positions.max(axis=0)]
     np.testing.assert_allclose(parsnip_minmax, ase_minmax, atol=1e-12)
+
+    if cols is not None:
+        # NOTE: ASE saves the occupancies of the most dominant species!
+        # Parsnip makes no assumptions regarding the correct occupancy
+        # Check all if full occupancy, partial if occ is ndarray and None if occ is None
+        mask = (
+            ... if cif_data.file["_atom_site_occupancy"] is None else occupancies == 1
+        )
+        np.testing.assert_equal(che_symbols[mask], ase_symbols[mask])
 
     if "zeolite" in cif_data.filename:
         return  # Four decimal places not sufficient to reconstruct this structure

--- a/tests/test_unitcells.py
+++ b/tests/test_unitcells.py
@@ -97,7 +97,7 @@ def test_build_unit_cell(cif_data, n_decimal_places, cols):
         parsnip_positions = read_data @ cif_data.file.lattice_vectors.T
     else:
         auxiliary_arr, parsnip_positions = read_data
-        parsnip_positions @= cif_data.file.lattice_vectors.T
+        parsnip_positions = parsnip_positions @ cif_data.file.lattice_vectors.T
 
         che_symbols = _arrstrip(auxiliary_arr[:, 0], r"[^A-Za-z]+")
         if isinstance(cols, list):


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
- Added the `additional_columns` arg to `cif.build_unit_cell` to allow for replication of element symbols (and other data from the array).
- Ensured consistent ordering of unit cell positions by sorting in order of symmetry operations
- Fixed type hinting in a few docstrings

### TODOs
- [x] Allow for additional data return
- [x] Update return types in docstring
- [x] Add tests for new functionality
- [x] Verify this meets use cases

### NOTE
`parsnip` ignores fractional occupancies while building unit cells. This is different than ASE, which always selects the [most dominant species](https://wiki.fysik.dtu.dk/ase/ase/io/formatoptions.html#ase.io.cif.read_cif). The position data is unaffected, but users extracting additional columns should be aware that the selection of a particular species is not guaranteed.

## Motivation and Context
As requested in #37, it would be useful to (optionally) replicate additional data alongside the atomic positions. This functionality has been added with the `additional_columns` arg in `build_unit_cell`, which allows returns associated data for each replicate atom. The current code returns an array for the positions and the additional data: while I considered a structured array, doing so makes indexing columns nontrivial.



**Multi-array return (this PR)**
```python
(array([['Si', '0.01013'],
       ['Si', '0.01013'],
       ...
       ['O', '0.00127'],
       ['O', '0.00127'],
       ['O', '0.00127']], dtype='<U7'), 
array([[0.    , 0.1522, 0.25  ],
       [0.    , 0.8478, 0.75  ],
       ...
       [0.2336, 0.1245, 0.5814],
       [0.7664, 0.8755, 0.4186],
       [0.2664, 0.3755, 0.0814]]))
```

**Structured array (alternate option)**
```python
[('Si', '0.01013', 0.    , 0.1522, 0.25  )
 ('Si', '0.01013', 0.    , 0.8478, 0.75  )
 ...
 ('O', '0.00127', 0.2336, 0.1245, 0.5814)
 ('O', '0.00127', 0.7664, 0.8755, 0.4186)
 ('O', '0.00127', 0.2664, 0.3755, 0.0814)]
```
Resolves #37

## Types of Changes
- [ ] Documentation update
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change


## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
- [x] I am familiar with the [Development Guidelines](https://github.com/glotzerlab/parsnip/blob/main/doc/source/development.rst)
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/parsnip/blob/main/ChangeLog.rst) and added my name to the [credits](https://github.com/glotzerlab/parsnip/blob/main/doc/source/credits.rst).
