### PR TITLE
Bump deprecated ubuntu-20.04 runners to 22.04

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -33,7 +33,7 @@ jobs:
       fail-fast: false # Legacy versions are much less stable - run tests independently
       matrix: # Code works on py3.6, but type annotations are broken
         python-version: ["3.8"]
-        runs-on: ["ubuntu-20.04", "macos-14"]
+        runs-on: ["ubuntu-22.04", "macos-14"]
     uses: ./.github/workflows/run_tests.yaml
     with:
       python-version: ${{ matrix.python-version }}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
GitHub Actions ubuntu-20.04 runners were deprecated, causing the legacy-python tests to fail. The runner OS for legacy tests was bumped to ubuntu-22.04 to resolve this.


## Types of Changes
<!-- Please select all items that apply, either now or after creating the pull request: -->
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality and should be merged into the `breaking` branch

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
- [ ] I am familiar with the [Development Guidelines](https://github.com/glotzerlab/parsnip/blob/main/doc/source/development.rst)
- [ ] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/parsnip/blob/main/ChangeLog.rst) and added my name to the [credits](https://github.com/glotzerlab/parsnip/blob/main/doc/source/credits.rst).
