### PR TITLE
Release 0.3.0

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -4,18 +4,18 @@ Changelog
 The format is based on `Keep a Changelog <http://keepachangelog.com/en/1.1.0/>`__.
 This project adheres to `Semantic Versioning <http://semver.org/spec/v2.0.0.html>`__.
 
-v0.X.X - 20XX-XX-XX
+v0.3.0 - 2025-07-16
 -------------------
 
 Added
 ~~~~~
-- Additional testpath flag to conftest
+- Additional testpath flag in conftest
 - Symbolic parsing mode for ``build_unit_cell``
 
 Changed
 ~~~~~~~
-- ``build_unit_cell`` now uses sympy by default if it is intalled - otherwise, it falls
-  back to the previous variant
+- ``build_unit_cell`` has a symbolic computation mode that allows for more accurate
+  construction of unit cells.
 
 Fixed
 ~~~~~

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -12,7 +12,7 @@ CURRENT_YEAR = datetime.date.today().year
 project = "parsnip"
 copyright = f"2024-{CURRENT_YEAR} The Regents of the University of Michigan"
 author = "Jen Bradley"
-release = "0.2.1"
+release = "0.3.0"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/parsnip/__init__.py
+++ b/parsnip/__init__.py
@@ -5,4 +5,4 @@
 
 from .parsnip import CifFile
 
-__version__ = "0.2.1"
+__version__ = "0.3.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "parsnip-cif"
-version = "0.2.1"
+version = "0.3.0"
 requires-python = ">=3.7"
 description = "Minimal library for parsing CIF & mmCIF files in Python."
 readme = "README.rst"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

### Added

- Additional testpath flag in conftest
- Symbolic parsing mode for ``build_unit_cell``

### Changed

- ``build_unit_cell`` has a symbolic computation mode that allows for more accurate
  construction of unit cells.

### Fixed

- Accessing data pairs with ``get_from_pairs`` or ``__getitem__`` now allows for case-insensitive searches
- Quote-delimited strings containing the delimiting character are now parsed properly
- ``build_unit_cell`` now rounds coordinates before wrapping into the box, fixing edge cases
  where boundary atoms were not properly deduplicated



## Types of Changes
<!-- Please select all items that apply, either now or after creating the pull request: -->
- [ ] Documentation update
- [x] Bug fix
- [x] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality and should be merged into the `breaking` branch

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
- [x] I am familiar with the [Development Guidelines](https://github.com/glotzerlab/parsnip/blob/main/doc/source/development.rst)
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] I have updated the [changelog](https://github.com/glotzerlab/parsnip/blob/main/ChangeLog.rst) and added my name to the [credits](https://github.com/glotzerlab/parsnip/blob/main/doc/source/credits.rst).
