### PR TITLE
Feat/cleanup parser

### DIFF
--- a/parsnip/parsnip.py
+++ b/parsnip/parsnip.py
@@ -925,7 +925,17 @@ class CifFile:
                         f"\n  Processed data: {loop_data}"
                     ) if "setting an array element with a sequence" in str(e) else e
                     raise ValueError(msg) from e
-                rectable.dtype = [*zip(loop_keys, [dt] * n_cols)]
+                labeled_type = [*zip(loop_keys, [dt] * n_cols)]
+                try:
+                    rectable.dtype = labeled_type
+                except ValueError as e:
+                    msg = (
+                        "Loop labels do not match the structure of parsed data.\n"
+                        f"  loop_labels:   {labeled_type}\n"
+                        "  data[:3, ...]: "
+                        f"{np.array2string(rectable[:2, :],prefix=' '*17)}\n"
+                    )
+                    raise ValueError(msg) from e
                 rectable = rectable.reshape(rectable.shape, order="F")
                 self.loops.append(rectable)
 

--- a/parsnip/parsnip.py
+++ b/parsnip/parsnip.py
@@ -82,6 +82,7 @@ from numpy.lib.recfunctions import structured_to_unstructured
 
 from parsnip._errors import ParseWarning
 from parsnip.patterns import (
+    _CIF_KEY,
     _PROG_PLUS,
     _PROG_STAR,
     _WHITESPACE,
@@ -948,10 +949,10 @@ class CifFile:
         return f"CifFile(fn={self._fn}) : {n_pairs} data entries, {n_tabs} data loops"
 
     PATTERNS: ClassVar = {
-        "key_value_general": rf"^(_[\w\.\-/\d\[\]]+?)\s{_PROG_PLUS}([^#]{_PROG_PLUS})",
+        "key_value_general": rf"^(_{_CIF_KEY}+?)\s{_PROG_PLUS}([^#]{_PROG_PLUS})",
         "loop_delimiter": rf"(loop_){_WHITESPACE}{_PROG_STAR}([^\n]{_PROG_STAR})",
         "block_delimiter": rf"(data_){_WHITESPACE}{_PROG_STAR}([^\n]{_PROG_STAR})",
-        "key_list": rf"_[\w_\.]{_PROG_PLUS}[\d\[\]]{_PROG_STAR}",
+        "key_list": rf"_{_CIF_KEY}{_PROG_STAR}",
         "space_delimited_data": (
             "("
             rf";[^;]*?;|"  # Non-semicolon data bracketed by semicolons

--- a/parsnip/parsnip.py
+++ b/parsnip/parsnip.py
@@ -844,8 +844,12 @@ class CifFile:
             pair = self._cpat["key_value_general"].match(line)
 
             # If we have a COD-style _key\n'long_value'
-            if pair is None and data_iter.peek("").lstrip()[:1] in "'\"" and data_iter.peek(None):
-                pair = self._cpat["key_value_general"].match(line+data_iter.peek(""))
+            if (
+                pair is None
+                and data_iter.peek("").lstrip()[:1] in "'\""
+                and data_iter.peek(None)
+            ):
+                pair = self._cpat["key_value_general"].match(line + data_iter.peek(""))
                 next(data_iter)
             if pair is not None:
                 self._pairs.update(
@@ -920,11 +924,15 @@ class CifFile:
                 try:
                     rectable = np.atleast_2d(loop_data)
                 except ValueError as e:
-                    msg =(
-                        "Ragged array identified: please check the loops' syntax."
-                        f"\n  Loop keys:      {loop_keys}"
-                        f"\n  Processed data: {loop_data}"
-                    ) if "setting an array element with a sequence" in str(e) else e
+                    msg = (
+                        (
+                            "Ragged array identified: please check the loops' syntax."
+                            f"\n  Loop keys:      {loop_keys}"
+                            f"\n  Processed data: {loop_data}"
+                        )
+                        if "setting an array element with a sequence" in str(e)
+                        else e
+                    )
                     raise ValueError(msg) from e
                 labeled_type = [*zip(loop_keys, [dt] * n_cols)]
                 try:
@@ -934,7 +942,7 @@ class CifFile:
                         "Loop labels do not match the structure of parsed data.\n"
                         f"  loop_labels:   {labeled_type}\n"
                         "  data[:3, ...]: "
-                        f"{np.array2string(rectable[:2, :],prefix=' '*17)}\n"
+                        f"{np.array2string(rectable[:2, :], prefix=' ' * 17)}\n"
                     )
                     raise ValueError(msg) from e
                 rectable = rectable.reshape(rectable.shape, order="F")

--- a/parsnip/parsnip.py
+++ b/parsnip/parsnip.py
@@ -938,13 +938,13 @@ class CifFile:
         return f"CifFile(fn={self._fn}) : {n_pairs} data entries, {n_tabs} data loops"
 
     PATTERNS: ClassVar = {
-        "key_value_general": rf"^(_[\w\.\-/\d\[\]]+)\s{_PROG_PLUS}([^#]{_PROG_PLUS})",
+        "key_value_general": rf"^(_[\w\.\-/\d\[\]]+?)\s{_PROG_PLUS}([^#]{_PROG_PLUS})",
         "loop_delimiter": rf"(loop_){_WHITESPACE}{_PROG_STAR}([^\n]{_PROG_STAR})",
         "block_delimiter": rf"(data_){_WHITESPACE}{_PROG_STAR}([^\n]{_PROG_STAR})",
         "key_list": rf"_[\w_\.]{_PROG_PLUS}[\d\[\]]{_PROG_STAR}",
         "space_delimited_data": (
             "("
-            rf";[^;]{_PROG_STAR};|"  # Non-semicolon data bracketed by semicolons
+            rf";[^;]*?;|"  # Non-semicolon data bracketed by semicolons
             r"'(?:'\S|[^'])*'|"  # Data with single quotes not followed by \s
             # rf"\"[^\"]{_PROG_STAR}\"|"  # Data with double quotes
             rf"[^';\"\s]{_PROG_STAR}"  # Additional non-bracketed data

--- a/parsnip/parsnip.py
+++ b/parsnip/parsnip.py
@@ -938,7 +938,7 @@ class CifFile:
         return f"CifFile(fn={self._fn}) : {n_pairs} data entries, {n_tabs} data loops"
 
     PATTERNS: ClassVar = {
-        "key_value_general": rf"^(_[\w\.\-/\[\d\]]+)\s{_PROG_PLUS}([^#]{_PROG_PLUS})",
+        "key_value_general": rf"^(_[\w\.\-/\d\[\]]+)\s{_PROG_PLUS}([^#]{_PROG_PLUS})",
         "loop_delimiter": rf"(loop_){_WHITESPACE}{_PROG_STAR}([^\n]{_PROG_STAR})",
         "block_delimiter": rf"(data_){_WHITESPACE}{_PROG_STAR}([^\n]{_PROG_STAR})",
         "key_list": rf"_[\w_\.]{_PROG_PLUS}[\d\[\]]{_PROG_STAR}",

--- a/parsnip/parsnip.py
+++ b/parsnip/parsnip.py
@@ -84,6 +84,7 @@ from parsnip._errors import ParseWarning
 from parsnip.patterns import (
     _PROG_PLUS,
     _PROG_STAR,
+    _WHITESPACE,
     _accumulate_nonsimple_data,
     _box_from_lengths_and_angles,
     _bracket_pattern,
@@ -938,9 +939,9 @@ class CifFile:
 
     PATTERNS: ClassVar = {
         "key_value_general": rf"^(_[\w\.\-/\[\d\]]+)\s{_PROG_PLUS}([^#]{_PROG_PLUS})",
-        "loop_delimiter": rf"(loop_)[ |\t]{_PROG_STAR}([^\n]{_PROG_STAR})",
-        "block_delimiter": rf"(data_)[ |\t]{_PROG_STAR}([^\n]{_PROG_STAR})",
-        "key_list": rf"_[\w_\.{_PROG_STAR}]{_PROG_PLUS}[\[\d\]]{_PROG_STAR}",
+        "loop_delimiter": rf"(loop_){_WHITESPACE}{_PROG_STAR}([^\n]{_PROG_STAR})",
+        "block_delimiter": rf"(data_){_WHITESPACE}{_PROG_STAR}([^\n]{_PROG_STAR})",
+        "key_list": rf"_[\w_\.]{_PROG_PLUS}[\d\[\]]{_PROG_STAR}",
         "space_delimited_data": (
             r"("
             rf"\;[^\;]{_PROG_STAR}\;|"  # Non-semicolon data bracketed by semicolons

--- a/parsnip/parsnip.py
+++ b/parsnip/parsnip.py
@@ -944,10 +944,10 @@ class CifFile:
         "space_delimited_data": (
             r"("
             rf"\;[^\;]{_PROG_STAR}\;|"  # Non-semicolon data bracketed by semicolons
-            r"\'(?:'[^\s]|[^'])*\'|"  # Data with single quotes not followed by \s
+            r"\'(?:'\S|[^'])*\'|"  # Data with single quotes not followed by \s
             rf"\"[^\"]{_PROG_STAR}\"|"  # Data with double quotes
             rf"[^\'\"\;\s]{_PROG_STAR}"  # Additional non-bracketed data
-            rf")[\s]{_PROG_STAR}"
+            rf")"
         ),
     }
     """Regex patterns used when parsing files.

--- a/parsnip/parsnip.py
+++ b/parsnip/parsnip.py
@@ -943,12 +943,12 @@ class CifFile:
         "block_delimiter": rf"(data_){_WHITESPACE}{_PROG_STAR}([^\n]{_PROG_STAR})",
         "key_list": rf"_[\w_\.]{_PROG_PLUS}[\d\[\]]{_PROG_STAR}",
         "space_delimited_data": (
-            r"("
+            "("
             rf"\;[^\;]{_PROG_STAR}\;|"  # Non-semicolon data bracketed by semicolons
             r"\'(?:'\S|[^'])*\'|"  # Data with single quotes not followed by \s
-            rf"\"[^\"]{_PROG_STAR}\"|"  # Data with double quotes
+            # rf"\"[^\"]{_PROG_STAR}\"|"  # Data with double quotes
             rf"[^\'\"\;\s]{_PROG_STAR}"  # Additional non-bracketed data
-            rf")"
+            ")"
         ),
     }
     """Regex patterns used when parsing files.

--- a/parsnip/parsnip.py
+++ b/parsnip/parsnip.py
@@ -944,10 +944,10 @@ class CifFile:
         "key_list": rf"_[\w_\.]{_PROG_PLUS}[\d\[\]]{_PROG_STAR}",
         "space_delimited_data": (
             "("
-            rf"\;[^\;]{_PROG_STAR}\;|"  # Non-semicolon data bracketed by semicolons
-            r"\'(?:'\S|[^'])*\'|"  # Data with single quotes not followed by \s
+            rf";[^;]{_PROG_STAR};|"  # Non-semicolon data bracketed by semicolons
+            r"'(?:'\S|[^'])*'|"  # Data with single quotes not followed by \s
             # rf"\"[^\"]{_PROG_STAR}\"|"  # Data with double quotes
-            rf"[^\'\"\;\s]{_PROG_STAR}"  # Additional non-bracketed data
+            rf"[^';\"\s]{_PROG_STAR}"  # Additional non-bracketed data
             ")"
         ),
     }

--- a/parsnip/parsnip.py
+++ b/parsnip/parsnip.py
@@ -838,6 +838,11 @@ class CifFile:
 
             # Extract key-value pairs and save to the internal state ===================
             pair = self._cpat["key_value_general"].match(line)
+
+            # If we have a COD-style _key\n'long_value'
+            if pair is None and data_iter.peek("").lstrip()[:1] in "'\"" and data_iter.peek(None):
+                pair = self._cpat["key_value_multiline"].match(line+data_iter.peek(""))
+                next(data_iter)
             if pair is not None:
                 self._pairs.update(
                     {
@@ -923,6 +928,7 @@ class CifFile:
 
     PATTERNS: ClassVar = {
         "key_value_general": r"^(_[\w\.\-/\[\d\]]+)\s+([^#]+)",
+        "key_value_multiline": r"^(_[\w\.\-/\[\d\]]+)\s+('[^#]+)",
         "loop_delimiter": r"([Ll][Oo][Oo][Pp]_)[ |\t]*([^\n]*)",
         "block_delimiter": r"([Dd][Aa][Tt][Aa]_)[ |\t]*([^\n]*)",
         "key_list": r"_[\w_\.*]+[\[\d\]]*",

--- a/parsnip/parsnip.py
+++ b/parsnip/parsnip.py
@@ -818,7 +818,7 @@ class CifFile:
         """
         return structured_to_unstructured(arr, copy=True)
 
-    def _parse(self, data_iter: Iterable):
+    def _parse(self, data_iter: peekable):
         """Parse the cif file into python objects."""
         for line in data_iter:
             if data_iter.peek(None) is None:

--- a/parsnip/patterns.py
+++ b/parsnip/patterns.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import re
 import warnings
+import sys
 
 import numpy as np
 from numpy.typing import ArrayLike
@@ -21,6 +22,14 @@ from parsnip._errors import ParseWarning
 
 ALLOWED_DELIMITERS = [";\n", "'''", '"""']
 """Delimiters allowed for nonsimple (multi-line) data entries."""
+
+
+_MATCH_KEY = r"^(_[\w\.\-/\[\d\]]+)"
+_WHITESPACE_PLUS = r"\s++" if sys.version_info >= (3, 11) else r"\s+"
+"""Possessively/greedily match one or more whitespace characters."""
+
+_NONNEWLINE_STAR = r"\s*+" if sys.version_info >= (3, 11) else r"\s*"
+"""Possessively/greedily match any number of non-newline whitespace characters."""
 
 
 _bracket_pattern = re.compile(r"(\[|\])")

--- a/parsnip/patterns.py
+++ b/parsnip/patterns.py
@@ -24,12 +24,10 @@ ALLOWED_DELIMITERS = [";\n", "'''", '"""']
 """Delimiters allowed for nonsimple (multi-line) data entries."""
 
 
-_MATCH_KEY = r"^(_[\w\.\-/\[\d\]]+)"
-_WHITESPACE_PLUS = r"\s++" if sys.version_info >= (3, 11) else r"\s+"
-"""Possessively/greedily match one or more whitespace characters."""
-
-_NONNEWLINE_STAR = r"\s*+" if sys.version_info >= (3, 11) else r"\s*"
-"""Possessively/greedily match any number of non-newline whitespace characters."""
+_PROG_STAR = "*+" if sys.version_info >= (3, 11) else "*"
+"""Progressively match prefix* if available, else greedily match."""
+_PROG_PLUS = "++" if sys.version_info >= (3, 11) else "+"
+"""Progressively match prefix+ if available, else greedily match."""
 
 
 _bracket_pattern = re.compile(r"(\[|\])")

--- a/parsnip/patterns.py
+++ b/parsnip/patterns.py
@@ -29,6 +29,11 @@ _PROG_STAR = "*+" if sys.version_info >= (3, 11) else "*"
 _PROG_PLUS = "++" if sys.version_info >= (3, 11) else "+"
 """Progressively match prefix+ if available, else greedily match."""
 
+_WHITESPACE = "[\t ]"
+"""Officially recognized whitespace characters according to the CIF 1.1 and 2.0 specs.
+
+See section 3.2 of http://dx.doi.org/10.1107/S1600576715021871 for clarification.
+"""
 
 _bracket_pattern = re.compile(r"(\[|\])")
 

--- a/parsnip/patterns.py
+++ b/parsnip/patterns.py
@@ -12,8 +12,8 @@ of string data extracted from CIF files by methods in ``parsnip.parse``.
 from __future__ import annotations
 
 import re
-import warnings
 import sys
+import warnings
 
 import numpy as np
 from numpy.typing import ArrayLike
@@ -29,16 +29,16 @@ _PROG_STAR = "*+" if sys.version_info >= (3, 11) else "*"
 _PROG_PLUS = "++" if sys.version_info >= (3, 11) else "+"
 """Progressively match prefix+ if available, else greedily match."""
 
-_CIF_KEY = r"[\w\.\-/\d\[\]]"
+_CIF_KEY = r"\S"
 """Match any of the valid characters in a CIF key or loop label.
 
-This includes the additional numerics and square brackets required to read mmCIF tables.
+See Table 1, entry "data-name" of dx.doi.org/10.1107/S1600576715021871
 """
 
 _WHITESPACE = "[\t ]"
 """Officially recognized whitespace characters according to the CIF 1.1 and 2.0 specs.
 
-See section 3.2 of http://dx.doi.org/10.1107/S1600576715021871 for clarification.
+See section 3.2 of dx.doi.org/10.1107/S1600576715021871 for clarification.
 """
 
 _bracket_pattern = re.compile(r"(\[|\])")

--- a/parsnip/patterns.py
+++ b/parsnip/patterns.py
@@ -29,6 +29,12 @@ _PROG_STAR = "*+" if sys.version_info >= (3, 11) else "*"
 _PROG_PLUS = "++" if sys.version_info >= (3, 11) else "+"
 """Progressively match prefix+ if available, else greedily match."""
 
+_CIF_KEY = r"[\w\.\-/\d\[\]]"
+"""Match any of the valid characters in a CIF key or loop label.
+
+This includes the additional numerics and square brackets required to read mmCIF tables.
+"""
+
 _WHITESPACE = "[\t ]"
 """Officially recognized whitespace characters according to the CIF 1.1 and 2.0 specs.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ from glob import glob
 import numpy as np
 import pytest
 from CifFile import CifFile as pycifRW
-from CifFile import StarError
+from CifFile import CifSyntaxError, StarError
 from gemmi import cif
 
 from parsnip import CifFile
@@ -25,7 +25,9 @@ def pycifrw_or_xfail(cif_data):
     try:
         return pycifRW(cif_data.filename).first_block()
     except StarError:
-        pytest.xfail("pycifRW failed to read the file!")
+        pytest.xfail("pycifRW raised a StarError!")
+    except CifSyntaxError:
+        pytest.xfail("pycifRW raised a CifSyntaxError!")
 
 
 def remove_invalid(s):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,20 +14,20 @@ from gemmi import cif
 
 from parsnip import CifFile
 
-ADDITIONAL_TEST_FILES_PATH = ""
+ADDITIONAL_TEST_FILES_PATH = "/Users/jenna/Downloads/asdf/*.cif"
 
 rng = np.random.default_rng(seed=161181914916)
 
 data_file_path = os.path.dirname(__file__) + "/sample_data/"
 
 
-def pycifrw_or_xfail(cif_data):
+def pycifrw_or_skip(cif_data):
     try:
         return pycifRW(cif_data.filename).first_block()
     except StarError:
-        pytest.xfail("pycifRW raised a StarError!")
+        pytest.skip("pycifRW raised a StarError!")
     except CifSyntaxError:
-        pytest.xfail("pycifRW raised a CifSyntaxError!")
+        pytest.skip("pycifRW raised a CifSyntaxError!")
 
 
 def remove_invalid(s):

--- a/tests/test_key_reader.py
+++ b/tests/test_key_reader.py
@@ -3,7 +3,7 @@ from conftest import (
     _gemmi_read_keys,
     all_files_mark,
     bad_cif,
-    pycifrw_or_xfail,
+    pycifrw_or_skip,
     random_keys_mark,
 )
 from more_itertools import flatten
@@ -23,7 +23,7 @@ def _array_assertion_verbose(keys, test_data, real_data):
 
 @all_files_mark
 def test_read_key_value_pairs(cif_data):
-    pycif = pycifrw_or_xfail(cif_data)
+    pycif = pycifrw_or_skip(cif_data)
 
     invalid = [*flatten(pycif.loops.values()), *cif_data.failing]
     all_keys = [key for key in pycif.true_case.values() if key.lower() not in invalid]

--- a/tests/test_table_reader.py
+++ b/tests/test_table_reader.py
@@ -25,7 +25,7 @@ def _gemmi_read_table(filename, keys):
     try:
         return np.array(cif.read_file(filename).sole_block().find(keys))
     except (RuntimeError, ValueError):
-        pytest.xfail("Gemmi failed to read file!")
+        pytest.skip("Gemmi failed to read file!")
 
 
 @all_files_mark

--- a/tests/test_table_reader.py
+++ b/tests/test_table_reader.py
@@ -8,7 +8,7 @@ from conftest import (
     all_files_mark,
     bad_cif,
     cif_files_mark,
-    pycifrw_or_xfail,
+    pycifrw_or_skip,
 )
 from gemmi import cif
 from more_itertools import flatten
@@ -30,7 +30,7 @@ def _gemmi_read_table(filename, keys):
 
 @all_files_mark
 def test_reads_all_keys(cif_data):
-    pycif = pycifrw_or_xfail(cif_data)
+    pycif = pycifrw_or_skip(cif_data)
     loop_keys = [*flatten(pycif.loops.values())]
     all_keys = [key for key in pycif.true_case.values() if key.lower() in loop_keys]
 

--- a/tests/test_unitcells.py
+++ b/tests/test_unitcells.py
@@ -188,6 +188,8 @@ def test_build_accuracy(filename, n_decimal_places):
         return (p.strip("'")[:2] == "hR", int(re.sub(r"[^\w]", "", p)[2:]))
 
     cif = CifFile(filename)
+    if cif["*Person"] is None:
+        pytest.skip(reason="Test not valid if Pearson symbol is unknown")
     (is_rhombohedral, n), uc = (
         parse_pearson(cif["*Pearson"]),
         cif.build_unit_cell(n_decimal_places=n_decimal_places, parse_mode="sympy"),

--- a/tests/test_unitcells.py
+++ b/tests/test_unitcells.py
@@ -26,7 +26,7 @@ def _gemmi_read_table(filename, keys):
     try:
         return np.array(cif.read_file(filename).sole_block().find(keys))
     except (RuntimeError, ValueError):
-        pytest.xfail("Gemmi failed to read file!")
+        pytest.skip("Gemmi failed to read file!")
 
 
 @all_files_mark  # TODO: test with conversions to numeric as well


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

The following syntax is not supported:
```
_my_data_label
'my data entry on a newline'
```

Citations for particular features of the CIF spec have been added to `parsnip/patterns.py`


## Motivation and Context
As several group members are using COD CIF files, I wanted to make sure we were correctly parsing those cases. This PR handles a few new parsing patterns that did not appear in AFLOW files, and significantly cleans up the regular expression backend of the parser. In particular, I've removed all but one case that could result in backtracking, and have aligned a few patterns to match the CIF spec more precisely.

## Types of Changes
<!-- Please select all items that apply, either now or after creating the pull request: -->
- [ ] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality and should be merged into the `breaking` branch

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
- [ ] I am familiar with the [Development Guidelines](https://github.com/glotzerlab/parsnip/blob/main/doc/source/development.rst)
- [ ] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/parsnip/blob/main/ChangeLog.rst) and added my name to the [credits](https://github.com/glotzerlab/parsnip/blob/main/doc/source/credits.rst).
