### PR TITLE
Add tests for `\sloop_`

### DIFF
--- a/parsnip/parsnip.py
+++ b/parsnip/parsnip.py
@@ -851,7 +851,7 @@ class CifFile:
                 continue
 
             # TODO: could separate multi-block files in the future =====================
-            # block = re.match(self._cpat["block_delimiter"], line.lower())
+            # block = re.match(self._cpat["block_delimiter"], line.lower().lstrip())
             # if block is not None:
             #     continue
 
@@ -885,7 +885,8 @@ class CifFile:
 
             # Build up tables by incrementing through the iterator =====================
             loop = re.match(
-                self._cpat["loop_delimiter"], self._strip_comments(line.lower())
+                self._cpat["loop_delimiter"],
+                self._strip_comments(line.lower()).lstrip(),
             )
 
             if loop is not None:

--- a/tests/sample_data/COD_7228524.cif
+++ b/tests/sample_data/COD_7228524.cif
@@ -17,7 +17,7 @@
 # contributors.
 #
 data_7228524 # A comment
-loop_ # A comment on the loop_ line
+   loop_ # A comment on the loop_ line, which begins with a space
 _publ_author_name
 'Boer\'e, Ren\'e' #Note the excaped quotation mark
 'Hill, Nathan D. D.'


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
<!-- Describe your changes in detail -->

## Motivation and Context

A test file in mbuild has a line beginning with ` loop_`, which was handled correctly prior to #52 but was broken in the changes made to comment handling. This has now been addressed, and an additional test case has been added.

## Types of Changes
<!-- Please select all items that apply, either now or after creating the pull request: -->
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality and should be merged into the `breaking` branch

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
- [x] I am familiar with the [Development Guidelines](https://github.com/glotzerlab/parsnip/blob/main/doc/source/development.rst)
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] I have updated the [changelog](https://github.com/glotzerlab/parsnip/blob/main/ChangeLog.rst) and added my name to the [credits](https://github.com/glotzerlab/parsnip/blob/main/doc/source/credits.rst).
