### PR TITLE
Add in identity operation if no symops are found

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -27,6 +27,7 @@ Fixed
 ~~~~~
 - Data entries containing non-comment pound signs are no longer truncated
 - Comments on ``loop_`` keyword lines no longer cause parse errors
+- Unit cells for files without symmetry operations are now parsed correctly
 
 
 v0.3.1 - 2025-07-16

--- a/parsnip/parsnip.py
+++ b/parsnip/parsnip.py
@@ -599,6 +599,7 @@ class CifFile:
             raise ValueError(f"Parse mode '{parse_mode}' not in {valid_modes}.")
 
         symops = self.symops
+        symops = symops if symops is not None else "x, y, z"
 
         if additional_columns is not None:
             # Find the table of Wyckoff positions and compare to keys in additional_data
@@ -619,7 +620,7 @@ class CifFile:
         cell_matrix = _matrix_from_lengths_and_angles(*cell)
 
         symops_str = np.array2string(
-            symops, separator=",", threshold=np.inf, floatmode="unique"
+            np.array(symops), separator=",", threshold=np.inf, floatmode="unique"
         )
 
         frac_strs = self.get_from_loops(self.__class__._WYCKOFF_KEYS)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->


## Motivation and Context
Previously, parsnip would fail if a unit cell was built without symmetry operations. This caused failures when testing integration with MBuild, and has been fixed by defaulting to the identity element "x, y, z" in the case where no symops are provided

## Types of Changes
<!-- Please select all items that apply, either now or after creating the pull request: -->
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality and should be merged into the `breaking` branch

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
- [x] I am familiar with the [Development Guidelines](https://github.com/glotzerlab/parsnip/blob/main/doc/source/development.rst)
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] I have updated the [changelog](https://github.com/glotzerlab/parsnip/blob/main/ChangeLog.rst) and added my name to the [credits](https://github.com/glotzerlab/parsnip/blob/main/doc/source/credits.rst).
