### PR TITLE
Fix links in the pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,4 +20,4 @@
 <!-- Please select all items that apply either now or after creating the pull request. -->
 - [ ] I am familiar with the [Development Guidelines](https://github.com/glotzerlab/parsnip/blob/main/doc/source/development.rst)
 - [ ] The changes introduced by this pull request are covered by existing or newly introduced tests.
-- [ ] I have updated the [changelog](https://github.com/glotzerlab/parsnip/blob/main/ChangeLog.rst) and added my name to the [credits](https://github.com/glotzerlab/parsnip/blob/main/doc/source/credits.rst).
+- [ ] I have updated the [changelog](https://github.com/glotzerlab/parsnip/blob/main/changelog.rst) and added my name to the [credits](https://github.com/glotzerlab/parsnip/blob/main/credits.rst).


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

```diff
- - [ ] I have updated the [changelog](https://github.com/glotzerlab/parsnip/blob/main/ChangeLog.rst) and added my name to the [credits](https://github.com/glotzerlab/parsnip/blob/main/doc/source/credits.rst).
+ - [ ] I have updated the [changelog](https://github.com/glotzerlab/parsnip/blob/main/changelog.rst) and added my name to the [credits](https://github.com/glotzerlab/parsnip/blob/main/credits.rst).
```

## Motivation and Context

As mentioned in #202, the pull request template had incorrect links for the changelog and credits rst files. This is now resolved.

## Types of Changes
<!-- Please select all items that apply, either now or after creating the pull request: -->
- [x] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality and should be merged into the `breaking` branch

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
- [ ] I am familiar with the [Development Guidelines](https://github.com/glotzerlab/parsnip/blob/main/doc/source/development.rst)
- [ ] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/parsnip/blob/main/ChangeLog.rst) and added my name to the [credits](https://github.com/glotzerlab/parsnip/blob/main/doc/source/credits.rst).
