### PR TITLE
Improve the performance of our parser by eliminating redundant work

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -12,6 +12,7 @@ Added
 - New rational parsing mode based on ``fractions.Fraction`` (#161)
 - Spacegroup symop lookup when a table of translation operators is not provided (#160)
 - Support for ``loop_`` data entries containing unescaped quotes (#162)
+- Improved performance when parsing well-structured CIF files (#222)
 
 Changed
 ~~~~~~~

--- a/parsnip/parsnip.py
+++ b/parsnip/parsnip.py
@@ -1023,13 +1023,16 @@ class CifFile:
                     )
                     loop_keys.extend(self._cpat["key_list"].findall(line))
 
+                max_len = 0
                 while _is_data(data_iter.peek(None)):
                     line = _accumulate_nonsimple_data(
                         data_iter, _strip_comments(next(data_iter))
                     )
                     parsed_line = self._cpat["space_delimited_data"].findall(line)
                     parsed_line = [m for m in parsed_line if m != "" and m != ","]
-                    loop_data.extend([parsed_line] if parsed_line else [])
+                    if parsed_line:
+                        loop_data.append(parsed_line)
+                        max_len = max(max_len, max(map(len, parsed_line)))
 
                 n_elements, n_cols = (
                     sum(len(row) for row in loop_data),
@@ -1058,7 +1061,7 @@ class CifFile:
                     msg = "Loop data is empty, but n_cols > 0: check CIF file syntax."
                     _warn_or_err(msg, self._strict)
                     continue
-                dt = _dtype_from_int(max(len(s) for l in loop_data for s in l))
+                dt = _dtype_from_int(max_len)
 
                 if len(set(loop_keys)) < len(loop_keys):
                     msg = "Duplicate loop keys detected - table will not be processed."

--- a/parsnip/parsnip.py
+++ b/parsnip/parsnip.py
@@ -1028,8 +1028,11 @@ class CifFile:
                     line = _accumulate_nonsimple_data(
                         data_iter, _strip_comments(next(data_iter))
                     )
-                    parsed_line = self._cpat["space_delimited_data"].findall(line)
-                    parsed_line = [m for m in parsed_line if m != "" and m != ","]
+                    if "'" not in line and '"' not in line and ";" not in line:
+                        parsed_line = line.split()
+                    else:
+                        parsed_line = self._cpat["space_delimited_data"].findall(line)
+                        parsed_line = [m for m in parsed_line if m != "" and m != ","]
                     if parsed_line:
                         loop_data.append(parsed_line)
                         max_len = max(max_len, max(map(len, parsed_line)))


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

Code that handles the worst-case portions of the cif grammar (multiline strings, containing quotes, inside tables) is now optional and skipped for less degenerate cases. This offers major performance improvements without impacting the actual functionality. This is tested against table 1 for the JOSS paper and against the existing test suite.

## Motivation and Context
When running the benchmarks for #221 I noticed a few functions that were overrepresented in the profile relative to what I expected. This PR resolves these issues and improves performance.


## Types of Changes
<!-- Please select all items that apply, either now or after creating the pull request: -->
- [ ] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality and should be merged into the `breaking` branch

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
- [x] I am familiar with the [Development Guidelines](https://github.com/glotzerlab/parsnip/blob/main/doc/source/development.rst)
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] I have updated the [changelog](https://github.com/glotzerlab/parsnip/blob/main/changelog.rst) and added my name to the [credits](https://github.com/glotzerlab/parsnip/blob/main/credits.rst).
