### PR TITLE
Snap fractions near high-symmetry sites to their exact representation

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -13,6 +13,9 @@ Added
 - Spacegroup symop lookup when a table of translation operators is not provided (#160)
 - Support for ``loop_`` data entries containing unescaped quotes (#162)
 - Improved performance when parsing well-structured CIF files (#222)
+- Configurable toggle for "snapping" near-fractional Wyckoff positions to exact ratios.
+  This improves the parsing accuracy for structures with incorrectly or inconsistently
+  rounded fractions (#223)
 
 Changed
 ~~~~~~~

--- a/doc/source/example_noisy.rst
+++ b/doc/source/example_noisy.rst
@@ -36,7 +36,7 @@ places of accuracy, while the symmetry operations are provided in a rational for
 **parsnip**'s default settings are able to correctly reproduce the unit cell -- but
 the mismatch between numerical data and the symmetry operation strings can cause issues.
 If we truncate the Wyckoff position data, even by one decimal place, the additional
-numerical error can cause errors in our final structure:
+numerical error can result in extra atoms in the output structure:
 
 .. literalinclude:: hP3-four-decimal-places.cif
    :diff: hP3.cif

--- a/doc/source/example_noisy.rst
+++ b/doc/source/example_noisy.rst
@@ -35,27 +35,52 @@ places of accuracy, while the symmetry operations are provided in a rational for
 
 **parsnip**'s default settings are able to correctly reproduce the unit cell -- but
 the mismatch between numerical data and the symmetry operation strings can cause issues.
-If we truncate the Wyckoff position data, even by one decimal place, we might expect
-the reconstructed crystal to contain duplicate atoms:
+If we truncate the Wyckoff position data, even by one decimal place, the additional
+numerical error can cause errors in our final structure:
 
 .. literalinclude:: hP3-four-decimal-places.cif
    :diff: hP3.cif
 
-However, **parsnip**'s rational mode recognizes truncated representations of exact
-fractions (e.g., ``0.3333`` is identified as ``1/3``) and snaps them to their exact
-values before applying symmetry operations. This means the truncated file still
-produces the correct structure:
-
 .. doctest::
 
     >>> lower_precision_cif = CifFile("hP3-four-decimal-places.cif")
-    >>> uc = lower_precision_cif.build_unit_cell(n_decimal_places=4)
+    >>> uc = lower_precision_cif.build_unit_cell(n_decimal_places=4, snap_fractions=False)
+    >>> uc # doctest: +SKIP
+    array([[0.2254    , 0.        , 0.3333    ],  # A
+           [0.        , 0.2254    , 0.66663333],  # B
+           [0.7746    , 0.7746    , 0.99996667],  # C
+           [0.2254    , 0.        , 0.33336667],  # A
+           [0.        , 0.2254    , 0.6667    ]]) # B
+    >>> uc.shape == correct_uc.shape
+    False
+
+To handle this, **parsnip**'s ``snap_fractions`` mode (which is enabled by default)
+recognizes truncated representations of exact fractions (e.g., ``0.3333`` is identified
+as ``1/3``) and snaps them to their exact values before applying symmetry operations:
+
+.. doctest::
+
+    >>> uc = lower_precision_cif.build_unit_cell(n_decimal_places=4, snap_fractions=True)
     >>> uc
     array([[0.2254    , 0.        , 0.33333333],
            [0.        , 0.2254    , 0.66666667],
            [0.7746    , 0.7746    , 0.        ]])
     >>> uc.shape == correct_uc.shape
     True
+
+Pass ``verbose=True`` to see which coordinates were snapped:
+
+.. doctest::
+
+    >>> lower_precision_cif.build_unit_cell(n_decimal_places=4, verbose=True) # doctest: +SKIP
+      Snapped 0.3333 -> 1/3
+    array([[0.2254    , 0.        , 0.33333333],
+           [0.        , 0.2254    , 0.66666667],
+           [0.7746    , 0.7746    , 0.        ]])
+
+
+Working with Low-Precision Files
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 For structures where coordinates are not near ideal fractions, the ``n_decimal_places``
 parameter controls deduplication precision. By default, **parsnip** uses three decimal

--- a/doc/source/example_noisy.rst
+++ b/doc/source/example_noisy.rst
@@ -27,53 +27,41 @@ places of accuracy, while the symmetry operations are provided in a rational for
     >>> # Let's make sure we reconstruct the unit cell's three atoms
     >>> correct_uc = cif.build_unit_cell()
     >>> correct_uc
-    array([[0.2254    , 0.        , 0.33333   ],
-           [0.        , 0.2254    , 0.66666333],
-           [0.7746    , 0.7746    , 0.99999667]])
+    array([[0.2254    , 0.        , 0.33333333],
+           [0.        , 0.2254    , 0.66666667],
+           [0.7746    , 0.7746    , 0.        ]])
     >>> site_multiplicity = int(cif["_atom_site_symmetry_multiplicity"].squeeze())
     >>> assert len(correct_uc) == site_multiplicity
 
 **parsnip**'s default settings are able to correctly reproduce the unit cell -- but
 the mismatch between numerical data and the symmetry operation strings can cause issues.
-If we truncate the Wyckoff position data, even by one decimal place, the reconstructed
-crystal contains duplicate atoms:
+If we truncate the Wyckoff position data, even by one decimal place, we might expect
+the reconstructed crystal to contain duplicate atoms:
 
 .. literalinclude:: hP3-four-decimal-places.cif
    :diff: hP3.cif
 
-Rebuilding our crystal results in an error:
+However, **parsnip**'s rational mode recognizes truncated representations of exact
+fractions (e.g., ``0.3333`` is identified as ``1/3``) and snaps them to their exact
+values before applying symmetry operations. This means the truncated file still
+produces the correct structure:
 
 .. doctest::
 
     >>> lower_precision_cif = CifFile("hP3-four-decimal-places.cif")
     >>> uc = lower_precision_cif.build_unit_cell(n_decimal_places=4)
-    >>> uc # doctest: +SKIP
-    array([[0.2254    , 0.        , 0.3333    ],  # A
-           [0.        , 0.2254    , 0.66663333],  # B
-           [0.7746    , 0.7746    , 0.99996667],  # C
-           [0.2254    , 0.        , 0.33336667],  # A
-           [0.        , 0.2254    , 0.6667    ]]) # B
-    >>> uc.shape == correct_uc.shape # Our unit cell has duplicate atoms!
-    False
+    >>> uc
+    array([[0.2254    , 0.        , 0.33333333],
+           [0.        , 0.2254    , 0.66666667],
+           [0.7746    , 0.7746    , 0.        ]])
+    >>> uc.shape == correct_uc.shape
+    True
 
-By default, **parsnip** uses three decimal places of accuracy to reconstruct crystals.
-This yields the best overall accuracy (tested with several thousand CIFs), but is not
-always the best choice in general. A good rule of thumb is to use one fewer decimal
-places than the CIF file contains. This ensures positions are rounded sufficiently to
-detect duplicate atoms, and avoids issues in complex structures where Wyckoff positions
-may be very close to one another. Using this setting results in the correct structure
-once again.
-
-
-.. doctest::
-
-    >>> cif = CifFile("hP3-four-decimal-places.cif")
-    >>> three_decimal_places = cif.build_unit_cell(n_decimal_places=3)
-    >>> three_decimal_places
-    array([[0.2254    , 0.        , 0.3333    ],
-           [0.        , 0.2254    , 0.66663333],
-           [0.7746    , 0.7746    , 0.99996667]])
-    >>> assert three_decimal_places.shape == correct_uc.shape
+For structures where coordinates are not near ideal fractions, the ``n_decimal_places``
+parameter controls deduplication precision. By default, **parsnip** uses three decimal
+places, which yields the best overall accuracy. A good rule of thumb is to use one
+fewer decimal place than the CIF file contains, ensuring positions are rounded
+sufficiently to detect duplicate atoms in complex structures.
 
 .. important::
 
@@ -85,7 +73,7 @@ once again.
 
         >>> cif = CifFile("hP3-four-decimal-places.cif")
         >>> one_decimal_place = cif.build_unit_cell(n_decimal_places=1)
-        >>> np.testing.assert_array_equal(one_decimal_place, three_decimal_places)
+        >>> np.testing.assert_array_equal(one_decimal_place, uc)
 
 
 Increasing Performance
@@ -107,9 +95,9 @@ best combination of performance and accuracy, installing the `cfractions`_ libra
     >>> cif = CifFile("hP3.cif")
     >>> faster = cif.build_unit_cell(n_decimal_places=4)
     >>> faster
-    array([[0.2254    , 0.        , 0.33333  ],
-           [0.        , 0.2254    , 0.6666633],
-           [0.7746    , 0.7746    , 0.99999667]])
+    array([[0.2254    , 0.        , 0.33333333],
+           [0.        , 0.2254    , 0.66666667],
+           [0.7746    , 0.7746    , 0.        ]])
     >>> assert faster.shape == correct_uc.shape
 
 .. _sympy: https://www.sympy.org/en/index.html

--- a/doc/source/example_noisy.rst
+++ b/doc/source/example_noisy.rst
@@ -51,7 +51,7 @@ numerical error can result in extra atoms in the output structure:
            [0.7746    , 0.7746    , 0.99996667],  # C
            [0.2254    , 0.        , 0.33336667],  # A
            [0.        , 0.2254    , 0.6667    ]]) # B
-    >>> uc.shape == correct_uc.shape
+    >>> uc.shape == correct_uc.shape # Our unit cell has duplicate atoms!
     False
 
 To handle this, **parsnip**'s ``snap_fractions`` mode (which is enabled by default)

--- a/parsnip/parsnip.py
+++ b/parsnip/parsnip.py
@@ -692,6 +692,10 @@ class CifFile:
             raise ParseError(msg)
 
         snapped = np.vectorize(_snap_coord_str)(frac_strs)
+        if verbose:
+            mask = snapped != frac_strs
+            for original, new in zip(frac_strs[mask], snapped[mask]):
+                print(f"  Snapped {original} -> {new}")
         all_frac_positions = [
             _safe_eval(symops_str, *xyz, parse_mode=parse_mode) for xyz in snapped
         ]  # Compute N_symmetry_elements coordinates for each Wyckoff site

--- a/parsnip/parsnip.py
+++ b/parsnip/parsnip.py
@@ -696,7 +696,9 @@ class CifFile:
             )
             raise ParseError(msg)
 
-        coords = np.vectorize(_snap_coord_str)(frac_strs) if snap_fractions else frac_strs
+        coords = (
+            np.vectorize(_snap_coord_str)(frac_strs) if snap_fractions else frac_strs
+        )
         if verbose:
             mask = coords != frac_strs
             for original, new in zip(frac_strs[mask], coords[mask]):

--- a/parsnip/parsnip.py
+++ b/parsnip/parsnip.py
@@ -706,7 +706,9 @@ class CifFile:
                 print(f"  Snapped {original} -> {new}")
         if parse_mode == "python_float":
             _fn = _compile_float_eval(symops_str)
-            wyckoff_floats = cast_array_to_float(coords, dtype=float)
+            wyckoff_floats = cast_array_to_float(
+                coords, dtype=float, handle_fractions=snap_fractions
+            )
             all_frac_positions = [_fn(*xyz) for xyz in wyckoff_floats]
         else:
             all_frac_positions = [

--- a/parsnip/parsnip.py
+++ b/parsnip/parsnip.py
@@ -546,8 +546,8 @@ class CifFile:
         n_decimal_places: int = 3,
         additional_columns: str | Iterable[str] | None = None,
         parse_mode: Literal["rational", "python_float", "sympy"] = "rational",
-        verbose: bool = False,
         snap_fractions: bool = True,
+        verbose: bool = False,
     ):
         """Reconstruct fractional atomic positions from Wyckoff sites and symops.
 
@@ -620,13 +620,13 @@ class CifFile:
                 (``parse_mode='python_float'``) arithmetic. 'rational' is more accurate
                 than 'python_float', but may take more time.
                 Default value = ``'rational'``
-            verbose : bool, optional
-                Whether to print debug information about the uniqueness checks.
-                Default value = ``False``
             snap_fractions : bool, optional
                 Whether to snap decimal approximations of common crystallographic
                 fractions (e.g., ``0.3333`` to ``1/3``) before applying symmetry
                 operations. Default value = ``True``
+            verbose : bool, optional
+                Whether to print debug information about the uniqueness checks.
+                Default value = ``False``
 
         Returns
         -------

--- a/parsnip/parsnip.py
+++ b/parsnip/parsnip.py
@@ -547,6 +547,7 @@ class CifFile:
         additional_columns: str | Iterable[str] | None = None,
         parse_mode: Literal["rational", "python_float", "sympy"] = "rational",
         verbose: bool = False,
+        snap_fractions: bool = True,
     ):
         """Reconstruct fractional atomic positions from Wyckoff sites and symops.
 
@@ -622,6 +623,10 @@ class CifFile:
             verbose : bool, optional
                 Whether to print debug information about the uniqueness checks.
                 Default value = ``False``
+            snap_fractions : bool, optional
+                Whether to snap decimal approximations of common crystallographic
+                fractions (e.g., ``0.3333`` to ``1/3``) before applying symmetry
+                operations. Default value = ``True``
 
         Returns
         -------
@@ -691,13 +696,13 @@ class CifFile:
             )
             raise ParseError(msg)
 
-        snapped = np.vectorize(_snap_coord_str)(frac_strs)
+        coords = np.vectorize(_snap_coord_str)(frac_strs) if snap_fractions else frac_strs
         if verbose:
-            mask = snapped != frac_strs
-            for original, new in zip(frac_strs[mask], snapped[mask]):
+            mask = coords != frac_strs
+            for original, new in zip(frac_strs[mask], coords[mask]):
                 print(f"  Snapped {original} -> {new}")
         all_frac_positions = [
-            _safe_eval(symops_str, *xyz, parse_mode=parse_mode) for xyz in snapped
+            _safe_eval(symops_str, *xyz, parse_mode=parse_mode) for xyz in coords
         ]  # Compute N_symmetry_elements coordinates for each Wyckoff site
         pos = np.vstack(all_frac_positions)
 

--- a/parsnip/parsnip.py
+++ b/parsnip/parsnip.py
@@ -103,6 +103,7 @@ from parsnip.patterns import (
     _lookup_symops,
     _matrix_from_lengths_and_angles,
     _safe_eval,
+    _snap_coord_str,
     _strip_comments,
     _strip_quotes,
     _try_cast_to_numeric,
@@ -690,8 +691,12 @@ class CifFile:
             )
             raise ParseError(msg)
 
+        snapped = np.array(
+            [[_snap_coord_str(frac_strs[i, j]) for j in range(frac_strs.shape[1])]
+             for i in range(frac_strs.shape[0])]
+        )
         all_frac_positions = [
-            _safe_eval(symops_str, *xyz, parse_mode=parse_mode) for xyz in frac_strs
+            _safe_eval(symops_str, *xyz, parse_mode=parse_mode) for xyz in snapped
         ]  # Compute N_symmetry_elements coordinates for each Wyckoff site
         pos = np.vstack(all_frac_positions)
 

--- a/parsnip/parsnip.py
+++ b/parsnip/parsnip.py
@@ -691,10 +691,7 @@ class CifFile:
             )
             raise ParseError(msg)
 
-        snapped = np.array(
-            [[_snap_coord_str(frac_strs[i, j]) for j in range(frac_strs.shape[1])]
-             for i in range(frac_strs.shape[0])]
-        )
+        snapped = np.vectorize(_snap_coord_str)(frac_strs)
         all_frac_positions = [
             _safe_eval(symops_str, *xyz, parse_mode=parse_mode) for xyz in snapped
         ]  # Compute N_symmetry_elements coordinates for each Wyckoff site

--- a/parsnip/patterns.py
+++ b/parsnip/patterns.py
@@ -126,7 +126,7 @@ def _snap_coord_str(s: str) -> str:
     except (ValueError, ZeroDivisionError):
         return s
     frac_part = abs(f) % 1
-    if frac_part == 0 or frac_part in _IDEAL_FRACS:
+    if frac_part in _IDEAL_FRACS:
         return s
     dp = len(clean.partition(".")[2]) if "." in clean else 0
     if dp == 0:

--- a/parsnip/patterns.py
+++ b/parsnip/patterns.py
@@ -131,8 +131,9 @@ def _snap_coord_str(s: str) -> str:
     dp = len(clean.partition(".")[2]) if "." in clean else 0
     if dp == 0:
         return s
+    half_ulp = 0.5 * 10**-dp
     for ideal in _IDEAL_FRACS:
-        if abs(frac_part - ideal) > 1e-3:
+        if abs(frac_part - ideal) > half_ulp:
             continue
         if round(float(ideal), dp) == round(float(frac_part), dp):
             int_part = abs(f) - frac_part

--- a/parsnip/patterns.py
+++ b/parsnip/patterns.py
@@ -263,7 +263,9 @@ def _write_debug_output(unique_indices, unique_counts, pos, check="Initial"):
     print()
 
 
-def cast_array_to_float(arr: ArrayLike | None, dtype: type = np.float32):
+def cast_array_to_float(
+    arr: ArrayLike | None, dtype: type = np.float32, *, handle_fractions: bool = False
+):
     """Cast a Numpy array to a dtype, pruning significant digits from numerical values.
 
     Args:
@@ -271,6 +273,9 @@ def cast_array_to_float(arr: ArrayLike | None, dtype: type = np.float32):
         dtype (type, optional):
             dtype to cast array to.
             Default value = ``np.float32``
+        handle_fractions (bool, optional):
+            When ``True``, interpret fraction strings (e.g. ``"1/3"``) via
+            ``Fraction`` before casting. Default value = ``False``
 
     Returns
     -------
@@ -281,9 +286,10 @@ def cast_array_to_float(arr: ArrayLike | None, dtype: type = np.float32):
     if np.array(arr).shape == (0,):
         return np.array((), dtype=dtype)
     arr = [(el if el is not None else "nan") for el in arr]
-    # if any(el is None for el in arr):
-    #     raise TypeError("Input array contains `None` and cannot be cast!")
-    return np.char.partition(arr, "(")[..., 0].astype(dtype)
+    stripped = np.char.partition(arr, "(")[..., 0]
+    if handle_fractions:
+        return np.vectorize(lambda s: dtype(Fraction(s)))(stripped)
+    return stripped.astype(dtype)
 
 
 def _accumulate_nonsimple_data(data_iter, line: str = ""):

--- a/parsnip/patterns.py
+++ b/parsnip/patterns.py
@@ -13,9 +13,9 @@ from __future__ import annotations
 
 import json
 import re
+import sys
 from fractions import Fraction as _StdFraction
 from importlib.util import find_spec as _find_spec
-import sys
 from pathlib import Path
 from typing import Literal, TypeVar
 
@@ -104,8 +104,13 @@ See section 3.2 of dx.doi.org/10.1107/S1600576715021871 for clarification.
 
 _SAFE_STRING_RE = re.compile(r"(\(\d+\))|[^\d\[\]\,\+\-\/\*\.]")
 _SAFE_FRACTN_RE = re.compile(rf"([-+]?\d{_PROG_STAR}[/.]?\d{_PROG_PLUS})")
-_IDEAL_FRACS = (Fraction(0), Fraction(1, 6), Fraction(1, 4), Fraction(1, 3),
-                Fraction(1, 2), Fraction(2, 3), Fraction(3, 4), Fraction(5, 6))
+_IDEAL_FRACS = (
+    Fraction(0),
+    Fraction(1, 6),
+    Fraction(1, 3),
+    Fraction(2, 3),
+    Fraction(5, 6),
+)
 _UNCERT_RE = re.compile(r"\(.*?\)")
 
 

--- a/parsnip/patterns.py
+++ b/parsnip/patterns.py
@@ -13,12 +13,19 @@ from __future__ import annotations
 
 import json
 import re
+from fractions import Fraction as _StdFraction
+from importlib.util import find_spec as _find_spec
 import sys
 from pathlib import Path
 from typing import Literal, TypeVar
 
 import numpy as np
 from numpy.typing import ArrayLike
+
+if _find_spec("cfractions") is not None:
+    from cfractions import Fraction
+else:
+    Fraction = _StdFraction
 
 
 def _normalize(string: str | None):
@@ -97,6 +104,9 @@ See section 3.2 of dx.doi.org/10.1107/S1600576715021871 for clarification.
 
 _SAFE_STRING_RE = re.compile(r"(\(\d+\))|[^\d\[\]\,\+\-\/\*\.]")
 _SAFE_FRACTN_RE = re.compile(rf"([-+]?\d{_PROG_STAR}[/.]?\d{_PROG_PLUS})")
+_IDEAL_FRACS = (Fraction(0), Fraction(1, 6), Fraction(1, 4), Fraction(1, 3),
+                Fraction(1, 2), Fraction(2, 3), Fraction(3, 4), Fraction(5, 6))
+_UNCERT_RE = re.compile(r"\(.*?\)")
 
 
 def _contains_wildcard(s: str) -> bool:
@@ -108,14 +118,30 @@ def _flatten_or_none(ls: list[T]):
     return None if not ls else ls[0] if len(ls) == 1 else ls
 
 
+def _snap_coord_str(s: str) -> str:
+    """Snap a coordinate string to an exact fraction if it is a valid rounding."""
+    clean = _UNCERT_RE.sub("", s)
+    try:
+        f = Fraction(clean)
+    except (ValueError, ZeroDivisionError):
+        return s
+    frac_part = abs(f) % 1
+    if frac_part == 0 or frac_part in _IDEAL_FRACS:
+        return s
+    dp = len(clean.partition(".")[2]) if "." in clean else 0
+    if dp == 0:
+        return s
+    for ideal in _IDEAL_FRACS:
+        if abs(frac_part - ideal) > 1e-3:
+            continue
+        if round(float(ideal), dp) == round(float(frac_part), dp):
+            int_part = abs(f) - frac_part
+            return str((1 if f >= 0 else -1) * (int_part + ideal))
+    return s
+
+
 def _rational_evaluate_array(arr: str) -> list[list[float]]:
     """Evaluate an array over the ring Q%1."""
-    from fractions import Fraction
-    from importlib.util import find_spec
-
-    if find_spec("cfractions") is not None:
-        from cfractions import Fraction
-
     one = Fraction(1)
     zero = Fraction(0)
 

--- a/tests/test_unitcells.py
+++ b/tests/test_unitcells.py
@@ -89,8 +89,11 @@ def test_build_unit_cell(cif_data, n_decimal_places, parse_mode, cols):
     if (
         "PDB_4INS_head.cif" in cif_data.filename
         or ("no42.cif" in cif_data.filename and n_decimal_places > 3)
-        or ("COD_7228524" in cif_data.filename and n_decimal_places > 5
-            and parse_mode == "python_float")
+        or (
+            "COD_7228524" in cif_data.filename
+            and n_decimal_places > 5
+            and parse_mode == "python_float"
+        )
     ):
         return
 

--- a/tests/test_unitcells.py
+++ b/tests/test_unitcells.py
@@ -112,9 +112,11 @@ def test_build_unit_cell(cif_data, n_decimal_places, parse_mode, cols):
         return  # ValueError was raised - exit the test
 
     if cols is None:
-        parsnip_positions = read_data @ cif_data.file.lattice_vectors.T
+        parsnip_frac = read_data
+        parsnip_positions = parsnip_frac @ cif_data.file.lattice_vectors.T
     else:
         auxiliary_arr, parsnip_positions = read_data
+        parsnip_frac = parsnip_positions
         parsnip_positions = parsnip_positions @ cif_data.file.lattice_vectors.T
 
         che_symbols = _arrstrip(auxiliary_arr[:, 0], r"[^A-Za-z]+")
@@ -138,7 +140,6 @@ def test_build_unit_cell(cif_data, n_decimal_places, parse_mode, cols):
     ase_minmax = [ase_positions.min(axis=0), ase_positions.max(axis=0)]
 
     np.testing.assert_array_equal(parsnip_positions.shape, ase_positions.shape)
-    np.testing.assert_allclose(parsnip_minmax, ase_minmax, atol=1e-12)
 
     if cols is not None:
         # NOTE: ASE saves the occupancies of the most dominant species!
@@ -151,7 +152,9 @@ def test_build_unit_cell(cif_data, n_decimal_places, parse_mode, cols):
 
     if "zeolite" in cif_data.filename or "no42" in cif_data.filename:
         return  # Reconstructed with different wrapping?
-    np.testing.assert_allclose(parsnip_positions, ase_positions, atol=1e-12)
+    ase_frac = ase_data.get_scaled_positions() % 1
+    diff = np.abs(parsnip_frac - ase_frac) % 1
+    np.testing.assert_allclose(np.minimum(diff, 1 - diff), 0, atol=1e-3)
 
 
 @cif_files_mark

--- a/tests/test_unitcells.py
+++ b/tests/test_unitcells.py
@@ -155,7 +155,7 @@ def test_build_unit_cell(cif_data, n_decimal_places, parse_mode, cols):
         return  # Reconstructed with different wrapping?
     ase_frac = ase_data.get_scaled_positions() % 1
     diff = np.abs(parsnip_frac - ase_frac) % 1
-    np.testing.assert_allclose(np.minimum(diff, 1 - diff), 0, atol=1e-3)
+    np.testing.assert_allclose(np.minimum(diff, 1 - diff), 0, atol=5e-6)
 
 
 @cif_files_mark

--- a/tests/test_unitcells.py
+++ b/tests/test_unitcells.py
@@ -89,7 +89,8 @@ def test_build_unit_cell(cif_data, n_decimal_places, parse_mode, cols):
     if (
         "PDB_4INS_head.cif" in cif_data.filename
         or ("no42.cif" in cif_data.filename and n_decimal_places > 3)
-        or ("COD_7228524" in cif_data.filename and n_decimal_places > 5)
+        or ("COD_7228524" in cif_data.filename and n_decimal_places > 5
+            and parse_mode == "python_float")
     ):
         return
 

--- a/tests/test_unitcells.py
+++ b/tests/test_unitcells.py
@@ -140,9 +140,6 @@ def test_build_unit_cell(cif_data, n_decimal_places, parse_mode, cols):
     )
     ase_symbols = np.array(ase_data.get_chemical_symbols())
 
-    parsnip_minmax = [parsnip_positions.min(axis=0), parsnip_positions.max(axis=0)]
-    ase_minmax = [ase_positions.min(axis=0), ase_positions.max(axis=0)]
-
     np.testing.assert_array_equal(parsnip_positions.shape, ase_positions.shape)
 
     if cols is not None:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

`pymatgen` [CifParser](https://pymatgen.org/pymatgen.io.html#pymatgen.io.cif.CifParser) includes logic for snapping fractional coordinates near 1/3 and 2/3 to exact values for better accuracy. This is valuable because it helps ensure structures accurately reproduce a target space group even when the data is recorded with limited precision.

In our code, this approach is written to round fractions nearby a common, repeating fraction (e.g. 0.3333 -> 1/3, 0.666 and 0.667 -> 2/3) to their exact rational representation. This improves build accuracy, as when we combine the rational positions with symmetry operations containing similar rational values (typically 1/2, 1/3, or 2/3) we get exactly rounded outputs.

## Motivation and Context

When responding to reviewer comments on space-group accuracy, I noticed that parsnip was not significantly more accurate than pymatgen, the most accurate library (in my benchmark). The doc page on noisy structures shows the benefits of the new code:

```python

    >>> lower_precision_cif = CifFile("hP3-four-decimal-places.cif")
    >>> uc = lower_precision_cif.build_unit_cell(n_decimal_places=4, snap_fractions=False)
    >>> uc
    array([[0.2254    , 0.        , 0.3333    ],  # A
           [0.        , 0.2254    , 0.66663333],  # B
           [0.7746    , 0.7746    , 0.99996667],  # C
           [0.2254    , 0.        , 0.33336667],  # A
           [0.        , 0.2254    , 0.6667    ]]) # B
    >>> uc.shape == correct_uc.shape # Our unit cell has duplicate atoms!
    False


    >>> uc = lower_precision_cif.build_unit_cell(n_decimal_places=4, snap_fractions=True)
    >>> uc
    array([[0.2254    , 0.        , 0.33333333],
           [0.        , 0.2254    , 0.66666667],
           [0.7746    , 0.7746    , 0.        ]])
    >>> uc.shape == correct_uc.shape
    True

```

```
# Data from accuracy page (code will be included in the JOSS PR)

## before this pr

Checked 9082 CIF files (1016 skipped, no space group in metadata)
symprec = 0.001

Library                    Correct   Too High   Too Low   Errors
-----------------------------------------------------------------
parsnip (rational, 3)         8457        101      *340*     184
ASE                           8445        105       356      176
gemmi                         8083         97       421      481
pymatgen                      8335         81        46      620



## after this pr

Checked 9082 CIF files (1016 skipped, no space group in metadata)
symprec = 0.001

Library                    Correct   Too High   Too Low   Errors
-----------------------------------------------------------------
parsnip (rational, 3)         8734        102        63      183
ASE                           8445        105       356      176
gemmi                         8083         97       421      481
pymatgen                      8335         81        46      620


```

## Types of Changes
<!-- Please select all items that apply, either now or after creating the pull request: -->
- [x] Documentation update
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality and should be merged into the `breaking` branch

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
- [x] I am familiar with the [Development Guidelines](https://github.com/glotzerlab/parsnip/blob/main/doc/source/development.rst)
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] I have updated the [changelog](https://github.com/glotzerlab/parsnip/blob/main/changelog.rst) and added my name to the [credits](https://github.com/glotzerlab/parsnip/blob/main/credits.rst).
