### PR TITLE
Improve performance in float parsing mode by reducing `eval` calls

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -13,6 +13,7 @@ Added
 - Spacegroup symop lookup when a table of translation operators is not provided (#160)
 - Support for ``loop_`` data entries containing unescaped quotes (#162)
 - Improved performance when parsing well-structured CIF files (#222)
+- Improved performance when using the ``python_float`` parse mode (#224)
 
 Changed
 ~~~~~~~

--- a/parsnip/parsnip.py
+++ b/parsnip/parsnip.py
@@ -95,6 +95,7 @@ from parsnip.patterns import (
     _WHITESPACE,
     _accumulate_nonsimple_data,
     _box_from_lengths_and_angles,
+    _compile_float_eval,
     _contains_wildcard,
     _dtype_from_int,
     _flatten_or_none,
@@ -690,9 +691,14 @@ class CifFile:
             )
             raise ParseError(msg)
 
-        all_frac_positions = [
-            _safe_eval(symops_str, *xyz, parse_mode=parse_mode) for xyz in frac_strs
-        ]  # Compute N_symmetry_elements coordinates for each Wyckoff site
+        if parse_mode == "python_float":
+            _fn = _compile_float_eval(symops_str)
+            wyckoff_floats = cast_array_to_float(frac_strs, dtype=float)
+            all_frac_positions = [_fn(*xyz) for xyz in wyckoff_floats]
+        else:
+            all_frac_positions = [
+                _safe_eval(symops_str, *xyz, parse_mode=parse_mode) for xyz in frac_strs
+            ]
         pos = np.vstack(all_frac_positions)
 
         # Wrap into box - works generally because these are fractional coordinates

--- a/parsnip/patterns.py
+++ b/parsnip/patterns.py
@@ -96,6 +96,7 @@ See section 3.2 of dx.doi.org/10.1107/S1600576715021871 for clarification.
 """
 
 _SAFE_STRING_RE = re.compile(r"(\(\d+\))|[^\d\[\]\,\+\-\/\*\.]")
+_SAFE_TEMPLATE_RE = re.compile(r"[^\d\[\]\,\+\-\/\*\.xyz]")
 _SAFE_FRACTN_RE = re.compile(rf"([-+]?\d{_PROG_STAR}[/.]?\d{_PROG_PLUS})")
 
 
@@ -144,6 +145,16 @@ def _sympy_evaluate_array(arr: str) -> list[list[float]]:
         ]
         for ls in arr.split("],")
     ]
+
+
+def _compile_float_eval(str_input: str):
+    """Pre-compile a symops template into a callable for ``python_float`` mode.
+
+    Sanitizes the template string and compiles it into a ``lambda x, y, z`` that
+    can be called repeatedly with different coordinates.
+    """
+    safe_template = _SAFE_TEMPLATE_RE.sub("", str_input.lower())
+    return eval(f"lambda x, y, z: {safe_template}", {"__builtins__": {}}, {})  # noqa: S307
 
 
 def _safe_eval(


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

Reduce the total number of calls to `eval` in the floating point parsing mode.

## Motivation and Context

Floating point parsing mode was suspiciously slow (slower than cfractions), which seemed odd. This PR solves the issue, which ended up being a result of many calls to python `eval`

## Types of Changes
<!-- Please select all items that apply, either now or after creating the pull request: -->
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality and should be merged into the `breaking` branch

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
- [x] I am familiar with the [Development Guidelines](https://github.com/glotzerlab/parsnip/blob/main/doc/source/development.rst)
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] I have updated the [changelog](https://github.com/glotzerlab/parsnip/blob/main/changelog.rst) and added my name to the [credits](https://github.com/glotzerlab/parsnip/blob/main/credits.rst).
