### PR TITLE
Use the default setting when a CIF's space group data is underspecified.

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -22,6 +22,8 @@ Changed
 ~~~~~~~
 - ``parse_mode='rational'`` is now the default setting in build_unit_cell (#161)
 - ``n_decimal_places=3`` is now the default setting in build_unit_cell (#161)
+- The default centering is now preferred when symmetry operations are looked up from
+  an underspecified space-group representation (#226)
 
 Deprecated
 ~~~~~~~~~~

--- a/parsnip/patterns.py
+++ b/parsnip/patterns.py
@@ -54,9 +54,14 @@ def _normalize_hall(string: str | None):
 
 with open(Path(__file__).parent / "symops.json") as f:
     # Process to extract the required data, in the specific format we need
+    # We move default settings to the end so that underspecific symbols like HM and IT
+    # use the standard setting where possible.
+    _items = sorted(
+        json.load(f).items(), key=lambda kv: kv[1]["is_default_setting"]
+    )
     _full_dict = {
         k: v | {"symops": np.asarray(v["symops"])[:, None]}
-        for (k, v) in json.load(f).items()
+        for (k, v) in _items
     }
     SYMOPS_BY_HALL = {_normalize_hall(k): v["symops"] for k, v in _full_dict.items()}
     SYMOPS_BY_HM = {

--- a/parsnip/patterns.py
+++ b/parsnip/patterns.py
@@ -37,7 +37,7 @@ def _normalize(string: str | None):
         string = string.strip('"')
     elif string[0] == "'" and string[-1] == "'":
         string = string.strip("'")
-    return re.sub(r"[\s;]", "", string)
+    return re.sub(r"[\s;_]", "", string)
 
 
 def _normalize_hall(string: str | None):

--- a/parsnip/patterns.py
+++ b/parsnip/patterns.py
@@ -56,12 +56,9 @@ with open(Path(__file__).parent / "symops.json") as f:
     # Process to extract the required data, in the specific format we need
     # We move default settings to the end so that underspecific symbols like HM and IT
     # use the standard setting where possible.
-    _items = sorted(
-        json.load(f).items(), key=lambda kv: kv[1]["is_default_setting"]
-    )
+    _items = sorted(json.load(f).items(), key=lambda kv: kv[1]["is_default_setting"])
     _full_dict = {
-        k: v | {"symops": np.asarray(v["symops"])[:, None]}
-        for (k, v) in _items
+        k: v | {"symops": np.asarray(v["symops"])[:, None]} for (k, v) in _items
     }
     SYMOPS_BY_HALL = {_normalize_hall(k): v["symops"] for k, v in _full_dict.items()}
     SYMOPS_BY_HM = {

--- a/tests/test_symmetry.py
+++ b/tests/test_symmetry.py
@@ -24,7 +24,7 @@ def lookup_test_cases():
 
     # H-M Symbols, tiled out into the full/short and with/without setting options.
     hm_map = {}
-    for data in RAW_DATA.values():
+    for data in sorted(RAW_DATA.values(), key=lambda d: d["is_default_setting"]):
         variants = [
             data["hermann_mauguin_full"],
             data["hermann_mauguin_full"].split(":")[0],
@@ -40,7 +40,7 @@ def lookup_test_cases():
 
     # International tables numbers
     it_map = {}
-    for data in RAW_DATA.values():
+    for data in sorted(RAW_DATA.values(), key=lambda d: d["is_default_setting"]):
         it_map[_normalize(data["table_number"])] = (
             data["table_number"],
             data["symops"],


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

For underspecified space group representations, the default setting is now preferred over other centerings.

## Motivation and Context

Previous code chose the ordering of settings based on the input data, meaning a non-default setting could be selected when a specific setting is not provided.

## Types of Changes
<!-- Please select all items that apply, either now or after creating the pull request: -->
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality and should be merged into the `breaking` branch

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
- [x] I am familiar with the [Development Guidelines](https://github.com/glotzerlab/parsnip/blob/main/doc/source/development.rst)
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/parsnip/blob/main/changelog.rst) and added my name to the [credits](https://github.com/glotzerlab/parsnip/blob/main/credits.rst).
