### PR TITLE
Improve error handling for missing box values inside the unit cell builder

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -25,6 +25,10 @@ Changed
 - The default centering is now preferred when symmetry operations are looked up from
   an underspecified space-group representation (#226)
 
+Fixed
+~~~~~
+- Missing cell data now raises an error when attempting to ``build_unit_cell`` (#227)
+
 Deprecated
 ~~~~~~~~~~
 - ``parse_mode='sympy'`` is now deprecated in favor of ``rational`` (#161)

--- a/parsnip/parsnip.py
+++ b/parsnip/parsnip.py
@@ -513,20 +513,21 @@ class CifFile:
         angle_keys = ("_cell?angle_alpha", "_cell?angle_beta", "_cell?angle_gamma")
         box_keys = ("_cell?length_a", "_cell?length_b", "_cell?length_c", *angle_keys)
 
+        raw_data = self[box_keys]
+        if any(value is None for value in raw_data):
+            missing = [k for k, v in zip(box_keys, raw_data) if v is None]
+            msg = f"Keys {missing} did not return any data!"
+            raise ValueError(msg)
+
         if self.cast_values:
-            cell_data = np.asarray([float(x) for x in self[box_keys]])
+            cell_data = np.asarray([float(x) for x in raw_data])
         else:
-            cell_data = cast_array_to_float(arr=self[box_keys], dtype=np.float64)
+            cell_data = cast_array_to_float(arr=raw_data, dtype=np.float64)
 
         self._raw_cell_keys = [self._wildcard_mapping[key] for key in box_keys]
 
         def angle_is_invalid(x: float):
             return x <= 0.0 or x >= 180.0
-
-        if any(value is None for value in cell_data):
-            missing = [k for k, v in zip(box_keys, cell_data) if v is None]
-            msg = f"Keys {missing} did not return any data!"
-            raise ValueError(msg)
 
         if any(angle_is_invalid(value) for value in cell_data[3:]):
             invalid = [

--- a/tests/test_unitcells.py
+++ b/tests/test_unitcells.py
@@ -159,6 +159,20 @@ def test_build_unit_cell(cif_data, n_decimal_places, parse_mode, cols):
 
 
 @cif_files_mark
+def test_missing_box_data(cif_data):
+    if "PDB" in cif_data.filename:
+        return
+
+    previous_cell_a = cif_data.file._pairs.pop("_cell_length_a", None)
+
+    with pytest.raises(ValueError, match="did not return any data"):
+        cif_data.file.read_cell_params()
+
+    if previous_cell_a is not None:
+        cif_data.file._pairs["_cell_length_a"] = previous_cell_a
+
+
+@cif_files_mark
 def test_invalid_unit_cell(cif_data):
     if "PDB" in cif_data.filename:
         return


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

Queries of box data in build_unit_cell will now fail gracefully if the required data is not present.

## Motivation and Context

Before this change, missing cell data would raise an opaque error when trying to evaluate `float(None)`. We now raise a nice value error if the keys are not present.

## Types of Changes
<!-- Please select all items that apply, either now or after creating the pull request: -->
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality and should be merged into the `breaking` branch

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
- [x] I am familiar with the [Development Guidelines](https://github.com/glotzerlab/parsnip/blob/main/doc/source/development.rst)
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/parsnip/blob/main/changelog.rst) and added my name to the [credits](https://github.com/glotzerlab/parsnip/blob/main/credits.rst).
