### PR TITLE
Slightly better handling of paired delimiters in multiline blocks

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -24,6 +24,8 @@ Changed
 - ``n_decimal_places=3`` is now the default setting in build_unit_cell (#161)
 - The default centering is now preferred when symmetry operations are looked up from
   an underspecified space-group representation (#226)
+- Handling of certain types of delimited data entries that contain the delimiter
+  themselves. This increases accuracy in a small percent of COD files (#228)
 
 Fixed
 ~~~~~

--- a/parsnip/patterns.py
+++ b/parsnip/patterns.py
@@ -299,8 +299,8 @@ def _accumulate_nonsimple_data(data_iter, line: str = ""):
     delimiter_count = 0
     while _line_is_continued(data_iter.peek(None)):
         while data_iter.peek(None) and delimiter_count < 2:
-            buffer = data_iter.peek().replace(" ", "")
-            if buffer[:1] == ";" or any(s in buffer for s in ALLOWED_DELIMITERS):
+            peek_prefix = data_iter.peek().lstrip()[:3]
+            if peek_prefix[:1] == ";" or peek_prefix == "'''" or peek_prefix == '"""':
                 delimiter_count += 1
             line += next(data_iter)
 

--- a/tests/test_ciffile.py
+++ b/tests/test_ciffile.py
@@ -83,6 +83,8 @@ def test_open_buffered(cif_data):
         ";\n  my text is here ;\n;\n",
         # Semicolons within multi-line text body are preserved
         ";\nThe cif grammar allows delimiters in delimited text; this is hard\n;\n",
+        # This structure (delimiter at end of text, followed by comment) will fail.
+        # "; \n my text is here ; # tempasdf",
     ],
     ids=["trailing_semicolon_in_body", "inline_semicolon_in_body"],
 )

--- a/tests/test_ciffile.py
+++ b/tests/test_ciffile.py
@@ -92,4 +92,3 @@ def test_semicolon_text_values(value):
     with pytest.warns(RuntimeWarning, match="parsed as a raw CIF data block"):
         cif = CifFile(cif_content)
     assert cif["_some_key"] == value.rstrip("\n")
-

--- a/tests/test_ciffile.py
+++ b/tests/test_ciffile.py
@@ -9,8 +9,6 @@ from parsnip import CifFile
 from parsnip._errors import ParseWarning
 
 
-
-
 @cif_files_mark
 def test_cast_values(cif_data):
     uncast_pairs = cif_data.file.pairs
@@ -75,6 +73,7 @@ def test_open_buffered(cif_data):
         cif = CifFile(f)
 
     _array_assertion_verbose(keys, cif.get_from_pairs(keys), stored_data)
+
 
 @pytest.mark.parametrize(
     "value",

--- a/tests/test_ciffile.py
+++ b/tests/test_ciffile.py
@@ -9,6 +9,8 @@ from parsnip import CifFile
 from parsnip._errors import ParseWarning
 
 
+
+
 @cif_files_mark
 def test_cast_values(cif_data):
     uncast_pairs = cif_data.file.pairs
@@ -73,3 +75,20 @@ def test_open_buffered(cif_data):
         cif = CifFile(f)
 
     _array_assertion_verbose(keys, cif.get_from_pairs(keys), stored_data)
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        # Semicolon inside text content should not be treated as a delimiter
+        ";\n  my text is here ;\n;\n",
+        # Semicolons within multi-line text body are preserved
+        ";\nThe cif grammar allows delimiters in delimited text; this is hard\n;\n",
+    ],
+    ids=["trailing_semicolon_in_body", "inline_semicolon_in_body"],
+)
+def test_semicolon_text_values(value):
+    cif_content = f"data_test\n_some_key\n{value}\n"
+    with pytest.warns(RuntimeWarning, match="parsed as a raw CIF data block"):
+        cif = CifFile(cif_content)
+    assert cif["_some_key"] == value.rstrip("\n")
+


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

Multiline delimiter search is now slightly more accurate, as we only strip whitespace where needed and we no longer select delimiters that occur after other characters.

Technically this can break keys whose delimiter is at the end of the line, but they are far less common than delimited data containing the required delimiter. This change is a net positive against our 10k sample from COD.

```text
# Now fails, where it previously worked
# Note this works just fine if there is no text after the closing delimiter.
; 
  my text is here ; # Here is a comment
```

```text
# Now succeeds, where it previously failed
;
  My name is Jen; I dislike this portion of the CIF grammar
;
```

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Resolves #?? -->

## Types of Changes
<!-- Please select all items that apply, either now or after creating the pull request: -->
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality and should be merged into the `breaking` branch

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
- [x] I am familiar with the [Development Guidelines](https://github.com/glotzerlab/parsnip/blob/main/doc/source/development.rst)
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] I have updated the [changelog](https://github.com/glotzerlab/parsnip/blob/main/changelog.rst) and added my name to the [credits](https://github.com/glotzerlab/parsnip/blob/main/credits.rst).
