### PR TITLE
Remove the real-space deduplication check in favor of only the fractional one.

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -26,6 +26,8 @@ Changed
   an underspecified space-group representation (#226)
 - Handling of certain types of delimited data entries that contain the delimiter
   themselves. This increases accuracy in a small percent of COD files (#228)
+- Site deduplication is now performed solely in fractional space where the rounding
+  tolerance directly maps to stored coordinates (#229)
 
 Fixed
 ~~~~~

--- a/parsnip/parsnip.py
+++ b/parsnip/parsnip.py
@@ -102,7 +102,6 @@ from parsnip.patterns import (
     _is_data,
     _is_key,
     _lookup_symops,
-    _matrix_from_lengths_and_angles,
     _safe_eval,
     _snap_coord_str,
     _strip_comments,
@@ -681,10 +680,6 @@ class CifFile:
                     "_fract_[xyz]` loop and cannot be included in the unit cell."
                 )
                 raise ValueError(msg)
-
-        # Read the cell params and convert to a matrix of basis vectors
-        cell = self.read_cell_params(degrees=False)
-        cell_matrix = _matrix_from_lengths_and_angles(*cell)
 
         symops_str = np.array2string(
             np.array(symops), separator=",", threshold=np.inf, floatmode="unique"

--- a/parsnip/parsnip.py
+++ b/parsnip/parsnip.py
@@ -719,25 +719,16 @@ class CifFile:
 
         # Wrap into box - works generally because these are fractional coordinates
         unrounded_pos = pos.copy() % 1
-        pos = pos.round(n_decimal_places) % 1
+        pos = np.round(unrounded_pos, n_decimal_places) % 1
+        pos[pos == 0.0] = 0.0 # Un-sign zeros for comparison
 
         # Filter unique points
         _, unique_fractional, unique_counts = np.unique(
             pos, return_index=True, return_counts=True, axis=0
         )
 
-        # Double-check for duplicates with real space coordinates
-        real_space_positions = pos @ cell_matrix
-
-        _, unique_realspace, unique_counts = np.unique(
-            real_space_positions.round(n_decimal_places),
-            return_index=True,
-            return_counts=True,
-            axis=0,
-        )
-
         # Merge unique points from realspace and fractional calculations
-        unique_indices = sorted({*unique_fractional} & {*unique_realspace})
+        unique_indices = sorted(unique_fractional)
 
         if verbose:
             _write_debug_output(

--- a/parsnip/parsnip.py
+++ b/parsnip/parsnip.py
@@ -720,7 +720,7 @@ class CifFile:
         # Wrap into box - works generally because these are fractional coordinates
         unrounded_pos = pos.copy() % 1
         pos = np.round(unrounded_pos, n_decimal_places) % 1
-        pos[pos == -0.0] = 0.0 # Un-sign zeros
+        pos[pos == -0.0] = 0.0  # Un-sign zeros
 
         # Filter unique points
         _, unique_fractional, unique_counts = np.unique(

--- a/parsnip/parsnip.py
+++ b/parsnip/parsnip.py
@@ -720,7 +720,7 @@ class CifFile:
         # Wrap into box - works generally because these are fractional coordinates
         unrounded_pos = pos.copy() % 1
         pos = np.round(unrounded_pos, n_decimal_places) % 1
-        pos[pos == 0.0] = 0.0 # Un-sign zeros for comparison
+        pos[pos == -0.0] = 0.0 # Un-sign zeros for comparison
 
         # Filter unique points
         _, unique_fractional, unique_counts = np.unique(

--- a/parsnip/parsnip.py
+++ b/parsnip/parsnip.py
@@ -720,7 +720,7 @@ class CifFile:
         # Wrap into box - works generally because these are fractional coordinates
         unrounded_pos = pos.copy() % 1
         pos = np.round(unrounded_pos, n_decimal_places) % 1
-        pos[pos == -0.0] = 0.0 # Un-sign zeros for comparison
+        pos[pos == -0.0] = 0.0 # Un-sign zeros
 
         # Filter unique points
         _, unique_fractional, unique_counts = np.unique(

--- a/tests/test_unitcells.py
+++ b/tests/test_unitcells.py
@@ -181,7 +181,7 @@ def test_invalid_unit_cell(cif_data):
     cif_data.file._pairs["_cell_angle_alpha"] = "180"
 
     with pytest.raises(ValueError, match="outside the valid range"):
-        cif_data.file.build_unit_cell()
+        cif_data.file.box
     cif_data.file._pairs["_cell_angle_alpha"] = previous_alpha
 
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

Earlier code used a combined real- and fractional-space deduplication check to catch a handful of edge cases. Since then, we've improved our accuracy handling enough that the real-space check is redundant. This PR removes the now-unneeded code.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Resolves #?? -->

## Types of Changes
<!-- Please select all items that apply, either now or after creating the pull request: -->
- [ ] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality and should be merged into the `breaking` branch

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
- [x] I am familiar with the [Development Guidelines](https://github.com/glotzerlab/parsnip/blob/main/doc/source/development.rst)
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] I have updated the [changelog](https://github.com/glotzerlab/parsnip/blob/main/changelog.rst) and added my name to the [credits](https://github.com/glotzerlab/parsnip/blob/main/credits.rst).
