### PR TITLE
Add additional "perfect" fractions and account for site symmetry when snapping sites

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -15,7 +15,7 @@ Added
 - Improved performance when parsing well-structured CIF files (#222)
 - Configurable toggle for "snapping" near-fractional Wyckoff positions to exact ratios.
   This improves the parsing accuracy for structures with incorrectly or inconsistently
-  rounded fractions (#223)
+  rounded fractions (#223, #230)
 - Improved performance when using the ``python_float`` parse mode (#224)
 
 Changed

--- a/parsnip/parsnip.py
+++ b/parsnip/parsnip.py
@@ -103,7 +103,7 @@ from parsnip.patterns import (
     _is_key,
     _lookup_symops,
     _safe_eval,
-    _snap_coord_str,
+    _snap_position,
     _strip_comments,
     _strip_quotes,
     _try_cast_to_numeric,
@@ -694,7 +694,9 @@ class CifFile:
             raise ParseError(msg)
 
         coords = (
-            np.vectorize(_snap_coord_str)(frac_strs) if snap_fractions else frac_strs
+            np.array([_snap_position(row) for row in frac_strs])
+            if snap_fractions
+            else frac_strs
         )
         if verbose:
             mask = coords != frac_strs

--- a/parsnip/parsnip.py
+++ b/parsnip/parsnip.py
@@ -1029,9 +1029,9 @@ class CifFile:
 
                 while _is_key(data_iter.peek(None)):
                     peeked = data_iter.peek(None)
-                    remainder = self._cpat["key_list"].sub(
-                        "", _strip_comments(peeked)
-                    ).strip()
+                    remainder = (
+                        self._cpat["key_list"].sub("", _strip_comments(peeked)).strip()
+                    )
                     if remainder:
                         break
                     line = _accumulate_nonsimple_data(

--- a/parsnip/parsnip.py
+++ b/parsnip/parsnip.py
@@ -1026,6 +1026,12 @@ class CifFile:
                         continue
 
                 while _is_key(data_iter.peek(None)):
+                    peeked = data_iter.peek(None)
+                    remainder = self._cpat["key_list"].sub(
+                        "", _strip_comments(peeked)
+                    ).strip()
+                    if remainder:
+                        break
                     line = _accumulate_nonsimple_data(
                         data_iter, _strip_comments(next(data_iter))
                     )

--- a/parsnip/patterns.py
+++ b/parsnip/patterns.py
@@ -121,7 +121,7 @@ _IDEAL_FRACS = (
     Fraction(5, 6),
     Fraction(11, 12),
 )
-_UNCERT_RE = re.compile(r"\(.*?\)")
+_NUMERIC_RE = re.compile(r"\(\d*?\)")  # The error part of a <Numeric> token
 
 
 def _contains_wildcard(s: str) -> bool:
@@ -135,7 +135,7 @@ def _flatten_or_none(ls: list[T]):
 
 def _snap_coord_str(s: str) -> str:
     """Snap a coordinate string to an exact fraction if it is a valid rounding."""
-    clean = _UNCERT_RE.sub("", s)
+    clean = _NUMERIC_RE.sub("", s)
     try:
         f = Fraction(clean)
     except (ValueError, ZeroDivisionError):
@@ -161,13 +161,13 @@ def _snap_position(row: np.ndarray) -> tuple[str, str, str]:
     sx, sy, sz = _snap_coord_str(rx), _snap_coord_str(ry), _snap_coord_str(rz)
 
     if sx != rx or sy != ry:
-        fx = Fraction(_UNCERT_RE.sub("", str(rx)))
-        fy = Fraction(_UNCERT_RE.sub("", str(ry)))
+        fx = Fraction(_NUMERIC_RE.sub("", str(rx)))
+        fy = Fraction(_NUMERIC_RE.sub("", str(ry)))
         if min(abs((fy - 2 * fx) % 1), 1 - abs((fy - 2 * fx) % 1)) < ONE_PERCENT:
             if sx != rx:
-                sy = str((2 * Fraction(_UNCERT_RE.sub("", sx))) % 1)
+                sy = str((2 * Fraction(_NUMERIC_RE.sub("", sx))) % 1)
             elif sy != ry:
-                sx = str((Fraction(_UNCERT_RE.sub("", sy)) / 2) % 1)
+                sx = str((Fraction(_NUMERIC_RE.sub("", sy)) / 2) % 1)
 
     return sx, sy, sz
 

--- a/parsnip/patterns.py
+++ b/parsnip/patterns.py
@@ -173,8 +173,6 @@ def _snap_position(row: np.ndarray) -> tuple[str, str, str]:
 
     return sx, sy, sz
 
-    return sx, sy, sz
-
 
 def _rational_evaluate_array(arr: str) -> list[list[float]]:
     """Evaluate an array over the ring Q%1."""

--- a/parsnip/patterns.py
+++ b/parsnip/patterns.py
@@ -155,28 +155,21 @@ def _snap_coord_str(s: str) -> str:
     return s
 
 
-def _frac(s: str) -> Fraction | None:
-    s = _UNCERT_RE.sub("", s)
-    try:
-        return Fraction(s)
-    except (ValueError, ZeroDivisionError):
-        return None
-
-
 def _snap_position(row: np.ndarray) -> tuple[str, str, str]:
     """Snap a Wyckoff position, preserving `y=2x%1` Wyckoff constraints."""
     rx, ry, rz = row[0], row[1], row[2]
     sx, sy, sz = _snap_coord_str(rx), _snap_coord_str(ry), _snap_coord_str(rz)
 
     if sx != rx or sy != ry:
-        fx, fy = _frac(str(rx)), _frac(str(ry))
-        if fx is None or fy is None:
-            return sx, sy, sz
+        fx = Fraction(_UNCERT_RE.sub("", str(rx)))
+        fy = Fraction(_UNCERT_RE.sub("", str(ry)))
         if min(abs((fy - 2 * fx) % 1), 1 - abs((fy - 2 * fx) % 1)) < ONE_PERCENT:
             if sx != rx:
-                sy = str((2 * _frac(sx)) % 1)
+                sy = str((2 * Fraction(_UNCERT_RE.sub("", sx))) % 1)
             elif sy != ry:
-                sx = str((_frac(sy) / 2) % 1)
+                sx = str((Fraction(_UNCERT_RE.sub("", sy)) / 2) % 1)
+
+    return sx, sy, sz
 
     return sx, sy, sz
 

--- a/parsnip/patterns.py
+++ b/parsnip/patterns.py
@@ -123,7 +123,7 @@ _IDEAL_FRACS = (
 )
 # The uncertainty part of a <Numeric> token. Note we are less strict than the official
 # grammar we allow for degenerate uncertainties without a numeric component
-_NUMERIC_RE = re.compile(r"\(\d*?\)")
+_NUMERIC_UNCERTAINTY_RE = re.compile(r"\(\d*?\)")
 
 
 def _contains_wildcard(s: str) -> bool:
@@ -137,7 +137,7 @@ def _flatten_or_none(ls: list[T]):
 
 def _snap_coord_str(s: str) -> str:
     """Snap a coordinate string to an exact fraction if it is a valid rounding."""
-    clean = _NUMERIC_RE.sub("", s)
+    clean = _NUMERIC_UNCERTAINTY_RE.sub("", s)
     try:
         f = Fraction(clean)
     except (ValueError, ZeroDivisionError):
@@ -163,13 +163,13 @@ def _snap_position(row: np.ndarray) -> tuple[str, str, str]:
     sx, sy, sz = _snap_coord_str(rx), _snap_coord_str(ry), _snap_coord_str(rz)
 
     if sx != rx or sy != ry:
-        fx = Fraction(_NUMERIC_RE.sub("", str(rx)))
-        fy = Fraction(_NUMERIC_RE.sub("", str(ry)))
+        fx = Fraction(_NUMERIC_UNCERTAINTY_RE.sub("", str(rx)))
+        fy = Fraction(_NUMERIC_UNCERTAINTY_RE.sub("", str(ry)))
         if min(abs((fy - 2 * fx) % 1), 1 - abs((fy - 2 * fx) % 1)) < ONE_PERCENT:
             if sx != rx:
-                sy = str((2 * Fraction(_NUMERIC_RE.sub("", sx))) % 1)
+                sy = str((2 * Fraction(_NUMERIC_UNCERTAINTY_RE.sub("", sx))) % 1)
             elif sy != ry:
-                sx = str((Fraction(_NUMERIC_RE.sub("", sy)) / 2) % 1)
+                sx = str((Fraction(_NUMERIC_UNCERTAINTY_RE.sub("", sy)) / 2) % 1)
 
     return sx, sy, sz
 

--- a/parsnip/patterns.py
+++ b/parsnip/patterns.py
@@ -148,9 +148,6 @@ def _snap_coord_str(s: str) -> str:
     for ideal in _IDEAL_FRACS:
         if abs(frac_part - ideal) > tol:
             continue
-        if round(float(ideal), dp) == round(float(frac_part), dp):
-            int_part = abs(f) - frac_part
-            return str((1 if f >= 0 else -1) * (int_part + ideal))
         int_part = abs(f) - frac_part
         return str((1 if f >= 0 else -1) * (int_part + ideal))
     return s

--- a/parsnip/patterns.py
+++ b/parsnip/patterns.py
@@ -126,7 +126,6 @@ _IDEAL_FRACS = (
 _NUMERIC_RE = re.compile(r"\(\d*?\)")
 
 
-
 def _contains_wildcard(s: str) -> bool:
     return "?" in s or "*" in s
 

--- a/parsnip/patterns.py
+++ b/parsnip/patterns.py
@@ -121,7 +121,10 @@ _IDEAL_FRACS = (
     Fraction(5, 6),
     Fraction(11, 12),
 )
-_NUMERIC_RE = re.compile(r"\(\d*?\)")  # The error part of a <Numeric> token
+# The uncertainty part of a <Numeric> token. Note we are less strict than the official
+# grammar we allow for degenerate uncertainties without a numeric component
+_NUMERIC_RE = re.compile(r"\(\d*?\)")
+
 
 
 def _contains_wildcard(s: str) -> bool:

--- a/parsnip/patterns.py
+++ b/parsnip/patterns.py
@@ -155,22 +155,28 @@ def _snap_coord_str(s: str) -> str:
     return s
 
 
+def _frac(s: str) -> Fraction | None:
+    s = _UNCERT_RE.sub("", s)
+    try:
+        return Fraction(s)
+    except (ValueError, ZeroDivisionError):
+        return None
+
+
 def _snap_position(row: np.ndarray) -> tuple[str, str, str]:
     """Snap a Wyckoff position, preserving `y=2x%1` Wyckoff constraints."""
     rx, ry, rz = row[0], row[1], row[2]
     sx, sy, sz = _snap_coord_str(rx), _snap_coord_str(ry), _snap_coord_str(rz)
 
     if sx != rx or sy != ry:
-        try:
-            fx = Fraction(_UNCERT_RE.sub("", str(rx)))
-            fy = Fraction(_UNCERT_RE.sub("", str(ry)))
-            if min(abs((fy - 2 * fx) % 1), 1 - abs((fy - 2 * fx) % 1)) < ONE_PERCENT:
-                if sx != rx:
-                    sy = str((2 * Fraction(_UNCERT_RE.sub("", sx))) % 1)
-                elif sy != ry:
-                    sx = str((Fraction(_UNCERT_RE.sub("", sy)) / 2) % 1)
-        except (ValueError, ZeroDivisionError):
-            pass
+        fx, fy = _frac(str(rx)), _frac(str(ry))
+        if fx is None or fy is None:
+            return sx, sy, sz
+        if min(abs((fy - 2 * fx) % 1), 1 - abs((fy - 2 * fx) % 1)) < ONE_PERCENT:
+            if sx != rx:
+                sy = str((2 * _frac(sx)) % 1)
+            elif sy != ry:
+                sx = str((_frac(sy) / 2) % 1)
 
     return sx, sy, sz
 

--- a/parsnip/patterns.py
+++ b/parsnip/patterns.py
@@ -27,6 +27,8 @@ if _find_spec("cfractions") is not None:
 else:
     Fraction = _StdFraction
 
+ONE_PERCENT = Fraction(1, 100)
+
 
 def _normalize(string: str | None):
     """Normalize a lookup by stripping spaces and matched quotes."""
@@ -151,6 +153,26 @@ def _snap_coord_str(s: str) -> str:
         int_part = abs(f) - frac_part
         return str((1 if f >= 0 else -1) * (int_part + ideal))
     return s
+
+
+def _snap_position(row: np.ndarray) -> tuple[str, str, str]:
+    """Snap a Wyckoff position, preserving `y=2x%1` Wyckoff constraints."""
+    rx, ry, rz = row[0], row[1], row[2]
+    sx, sy, sz = _snap_coord_str(rx), _snap_coord_str(ry), _snap_coord_str(rz)
+
+    if sx != rx or sy != ry:
+        try:
+            fx = Fraction(_UNCERT_RE.sub("", str(rx)))
+            fy = Fraction(_UNCERT_RE.sub("", str(ry)))
+            if min(abs((fy - 2 * fx) % 1), 1 - abs((fy - 2 * fx) % 1)) < ONE_PERCENT:
+                if sx != rx:
+                    sy = str((2 * Fraction(_UNCERT_RE.sub("", sx))) % 1)
+                elif sy != ry:
+                    sx = str((Fraction(_UNCERT_RE.sub("", sy)) / 2) % 1)
+        except (ValueError, ZeroDivisionError):
+            pass
+
+    return sx, sy, sz
 
 
 def _rational_evaluate_array(arr: str) -> list[list[float]]:

--- a/parsnip/patterns.py
+++ b/parsnip/patterns.py
@@ -109,10 +109,15 @@ _SAFE_TEMPLATE_RE = re.compile(r"[^\d\[\]\,\+\-\/\*\.xyz]")
 _SAFE_FRACTN_RE = re.compile(rf"([-+]?\d{_PROG_STAR}[/.]?\d{_PROG_PLUS})")
 _IDEAL_FRACS = (
     Fraction(0),
+    Fraction(1, 12),
     Fraction(1, 6),
     Fraction(1, 3),
+    Fraction(5, 12),
+    Fraction(1, 2),
+    Fraction(7, 12),
     Fraction(2, 3),
     Fraction(5, 6),
+    Fraction(11, 12),
 )
 _UNCERT_RE = re.compile(r"\(.*?\)")
 
@@ -137,15 +142,17 @@ def _snap_coord_str(s: str) -> str:
     if frac_part in _IDEAL_FRACS:
         return s
     dp = len(clean.partition(".")[2]) if "." in clean else 0
-    if dp == 0:
+    if dp <= 1:
         return s
-    half_ulp = 0.5 * 10**-dp
+    tol = Fraction(2, 3 * 10**dp)
     for ideal in _IDEAL_FRACS:
-        if abs(frac_part - ideal) > half_ulp:
+        if abs(frac_part - ideal) > tol:
             continue
         if round(float(ideal), dp) == round(float(frac_part), dp):
             int_part = abs(f) - frac_part
             return str((1 if f >= 0 else -1) * (int_part + ideal))
+        int_part = abs(f) - frac_part
+        return str((1 if f >= 0 else -1) * (int_part + ideal))
     return s
 
 

--- a/tests/test_unitcells.py
+++ b/tests/test_unitcells.py
@@ -155,7 +155,10 @@ def test_build_unit_cell(cif_data, n_decimal_places, parse_mode, cols):
         return  # Reconstructed with different wrapping?
     ase_frac = ase_data.get_scaled_positions() % 1
     diff = np.abs(parsnip_frac - ase_frac) % 1
-    np.testing.assert_allclose(np.minimum(diff, 1 - diff), 0, atol=5e-6)
+    # Because we snap 0.334 to exactly 1/3, our answer differs from ASE. Because no
+    # error is reported in this file, I'm not sure which is correct.
+    atol = 1e-3 if "needs_to_be_wrapped" in cif_data.filename else 5e-6
+    np.testing.assert_allclose(np.minimum(diff, 1 - diff), 0, atol=atol)
 
 
 @cif_files_mark


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

Snapping sites to exact fractions is now done with the Wyckoff site symmetry in mind, better aligning the results with the desired space group symmetry. 

## Motivation and Context

Prior to this change, coordinates nearby nonrepresentable fractions were "snapped" to their perfect sites individually, meaning the equations for a wyckoff site could be violated -- for example, if a site is `x y=2x 0`, snapping only x or y would break the symmetry of the site. This is now handled explicitly.

## Types of Changes
<!-- Please select all items that apply, either now or after creating the pull request: -->
- [ ] Documentation update
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality and should be merged into the `breaking` branch

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
- [x] I am familiar with the [Development Guidelines](https://github.com/glotzerlab/parsnip/blob/main/doc/source/development.rst)
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/parsnip/blob/main/changelog.rst) and added my name to the [credits](https://github.com/glotzerlab/parsnip/blob/main/credits.rst).
