### PR TITLE
Fix code block styling in performance page

### DIFF
--- a/doc/source/performance.rst
+++ b/doc/source/performance.rst
@@ -67,16 +67,16 @@ All benchmarks in this file were obtained using Python 3.13.2 on an M1 Macbook P
 reproduce the results on your own hardware, run the following commands from the root
 of the repository:
 
-.. code-block:: console
+.. code-block:: bash
 
-   > uv sync --group tables
+   uv sync --group tables
 
-   > # Measure parsnip's performance reading CIF files
-   > ./doc/generate_benchmark_plots/cif_parsing_benchmark.sh
+   # Measure parsnip's performance reading CIF files
+   ./doc/generate_benchmark_plots/cif_parsing_benchmark.sh
 
-   > # Compare the efficiency of various parsing modes
-   > ./doc/generate_benchmark_plots/parse_mode_benchmark_plot.py
+   # Compare the efficiency of various parsing modes
+   ./doc/generate_benchmark_plots/parse_mode_benchmark_plot.py
 
-   > # Measure the space group and unit cell reconstruction accuracy
-   > python _joss/generate_table_1.py
-   > python _joss/generate_table_2.py
+   # Measure the space group and unit cell reconstruction accuracy
+   python _joss/generate_table_1.py
+   python _joss/generate_table_2.py


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
Swap `.. console` block for `.. bash` for more consistent copying and styling

## Motivation and Context
### Before

<img width="950" height="308" alt="image" src="https://github.com/user-attachments/assets/f1aca404-af52-41d6-af38-39f1d312a17f" />

### After
<img width="872" height="297" alt="image" src="https://github.com/user-attachments/assets/cb855495-e922-45b6-a33f-4bb8a2f458d9" />

## Types of Changes
<!-- Please select all items that apply, either now or after creating the pull request: -->
- [x] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality and should be merged into the `breaking` branch

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
- [ ] I am familiar with the [Development Guidelines](https://github.com/glotzerlab/parsnip/blob/main/doc/source/development.rst)
- [ ] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [ ] I have updated the [changelog](https://github.com/glotzerlab/parsnip/blob/main/changelog.rst) and added my name to the [credits](https://github.com/glotzerlab/parsnip/blob/main/credits.rst).
