### PR TITLE
Fix Numpy 2.5 dtype casting

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -4,7 +4,7 @@ Changelog
 The format is based on `Keep a Changelog <http://keepachangelog.com/en/1.1.0/>`__.
 This project adheres to `Semantic Versioning <http://semver.org/spec/v2.0.0.html>`__.
 
-v1.0.1 - TBD
+v1.0.1 - XXXX-XX-XX
 -------------------
 
 Fixed

--- a/changelog.rst
+++ b/changelog.rst
@@ -4,6 +4,12 @@ Changelog
 The format is based on `Keep a Changelog <http://keepachangelog.com/en/1.1.0/>`__.
 This project adheres to `Semantic Versioning <http://semver.org/spec/v2.0.0.html>`__.
 
+v1.0.1 - TBD
+-------------------
+
+Fixed
+~~~~~
+
 v1.0.0 - 2026-07-08
 -------------------
 

--- a/changelog.rst
+++ b/changelog.rst
@@ -9,6 +9,7 @@ v1.0.1 - TBD
 
 Fixed
 ~~~~~
+- Fixed ``dtype`` conversion with Numpy 2.5 (#245)
 
 v1.0.0 - 2026-07-08
 -------------------

--- a/credits.rst
+++ b/credits.rst
@@ -4,4 +4,4 @@ Credits
 The following people have contributed to **parsnip**:
 
 * Jen Bradley, University of Michigan - *Creator and lead developer*
-* Doron Behar, The Hebrew University of Jerusalem 
+* Doron Behar, The Hebrew University of Jerusalem

--- a/credits.rst
+++ b/credits.rst
@@ -4,3 +4,4 @@ Credits
 The following people have contributed to **parsnip**:
 
 * Jen Bradley, University of Michigan - *Creator and lead developer*
+* Doron Behar, The Hebrew University of Jerusalem 

--- a/parsnip/parsnip.py
+++ b/parsnip/parsnip.py
@@ -1107,7 +1107,7 @@ class CifFile:
 
                 labeled_type = [*zip(loop_keys, [dt] * n_cols, strict=False)]
                 try:
-                    rectable.dtype = labeled_type
+                    rectable = rectable.view(labeled_type)
                 except ValueError as e:
                     msg = (
                         "Loop labels do not match the structure of parsed data.\n"


### PR DESCRIPTION
## Description

Fixes a test failure experienced with Numpy 2.5, due to the line changed in the PR.

## Motivation and Context

```
E   DeprecationWarning: Setting the dtype on a NumPy array has been deprecated in NumPy 2.5.
E   Instead of changing the dtype on an array x, create a new array with x.view(new_dtype)
```

## Types of Changes
<!-- Please select all items that apply, either now or after creating the pull request: -->
- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality and should be merged into the `breaking` branch

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
- [x] I am familiar with the [Development Guidelines](https://github.com/glotzerlab/parsnip/blob/main/doc/source/development.rst)
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] I have updated the [changelog](https://github.com/glotzerlab/parsnip/blob/main/changelog.rst) and added my name to the [credits](https://github.com/glotzerlab/parsnip/blob/main/credits.rst).
