### PR TITLE
Fix typo in paper text

### DIFF
--- a/_joss/paper.md
+++ b/_joss/paper.md
@@ -97,8 +97,8 @@ requiring postprocessing for studies where that data is unnecessary or incorrect
 than associating pure crystallographic data with atomic symbols or valence states by
 default, `parsnip` provides only the information required to reconstruct a particular
 structure unless otherwise queried. This approach offers benefits for users who do
-require atomic information, as we are able to provide access to arbirary data associated
-with the basis positions, rather than fixed keys as required by other tools.
+require atomic information, as we are able to provide access to arbitrary data
+associated with the basis positions, rather than fixed keys as required by other tools.
 
 # Software Design
 

--- a/_joss/paper.md
+++ b/_joss/paper.md
@@ -115,7 +115,7 @@ formats like *XYZ*, *MOL*, and *VTP* [@molIUPAC; @vtkBook].
 
 Our unique approach to the CIF specification extends to the design of our parser as
 well. While most existing tools in the space use parser generators based on the IUCR's
-formal grammar, we identified a non-neglible subset of CIF files that break the formal
+formal grammar, we identified a non-negligible subset of CIF files that break the formal
 specification but nevertheless contain useful data. To overcome this, `parsnip` does not
 validate the entire syntax tree of the CIF grammar: rather, we eagerly consume nodes
 near the leaves of the tree that appear to contain data. Most commonly, this allows


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

Addressed one spelling error from the paper review, and fixed another error found by `typos` cli.

`arbirary -> arbitrary`
`negligible -> negligible`


## Types of Changes
<!-- Please select all items that apply, either now or after creating the pull request: -->
- [x] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change<sup>1</sup>

<sup>1</sup>The change breaks (or has the potential to break) existing functionality and should be merged into the `breaking` branch

## Checklist:
<!-- Please select all items that apply either now or after creating the pull request. -->
- [x] I am familiar with the [Development Guidelines](https://github.com/glotzerlab/parsnip/blob/main/doc/source/development.rst)
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] I have updated the [changelog](https://github.com/glotzerlab/parsnip/blob/main/changelog.rst) and added my name to the [credits](https://github.com/glotzerlab/parsnip/blob/main/credits.rst).
